### PR TITLE
[FE & BE] Fixed Bugs

### DIFF
--- a/backend/src/route/library/album/index.ts
+++ b/backend/src/route/library/album/index.ts
@@ -3,7 +3,6 @@ import getAlbums from './controller';
 
 const route = express.Router();
 
-// test API: /POST
 route.get('/', getAlbums);
 
 export default route;

--- a/backend/tsconfig.json
+++ b/backend/tsconfig.json
@@ -46,7 +46,7 @@
     // "baseUrl": "./",                       /* Base directory to resolve non-absolute module names. */
     // "paths": {},                           /* A series of entries which re-map imports to lookup locations relative to the 'baseUrl'. */
     // "rootDirs": [],                        /* List of root folders whose combined content represents the structure of the project at runtime. */
-    // "typeRoots": [],                       /* List of folders to include type definitions from. */
+    "typeRoots": [ "overrides", "node_modules / @ types" ],                       /* List of folders to include type definitions from. */
     // "types": [],                           /* Type declaration files to be included in compilation. */
     // "allowSyntheticDefaultImports": true,  /* Allow default imports from modules with no default export. This does not affect code emit, just typechecking. */
     // "esModuleInterop": true,                  /* Enables emit interoperability between CommonJS and ES Modules via creation of namespace objects for all imports. Implies 'allowSyntheticDefaultImports'. */

--- a/frontend/src/components/Template/Library/index.tsx
+++ b/frontend/src/components/Template/Library/index.tsx
@@ -7,8 +7,14 @@ import { IoShuffleOutline } from 'react-icons/io5';
 
 import LargeButton from '@components/Common/Button/LargeButton';
 
+interface ILayout {
+  mainTitle: string;
+  type?: null | string;
+  children: any;
+}
+
 // title이라고 하면 _document랑 충돌남
-function Layout({ mainTitle, type = null, children }) {
+function Layout({ mainTitle, type, children }: ILayout) {
   return (
     <Wrapper>
       <Header>

--- a/frontend/src/pages/Library/MyArtist/index.tsx
+++ b/frontend/src/pages/Library/MyArtist/index.tsx
@@ -1,18 +1,16 @@
 import styled from '@styles/themed-components';
 
-import Library from '@components/Template/Library/index.tsx';
-import ArtistList from '@components/ArtistList'; 
-
+import Library from '@components/Template/Library';
+import ArtistList from '@components/ArtistList';
 
 const MyArtist = () => (
-  <Library mainTitle={'아티스트'}>
+  <Library mainTitle="아티스트">
     <Container>
       <ArtistList />
     </Container>
   </Library>
 );
 
-const Container = styled.div`
-`;
+const Container = styled.div``;
 
 export default MyArtist;

--- a/frontend/src/pages/Library/MyMixtape/index.tsx
+++ b/frontend/src/pages/Library/MyMixtape/index.tsx
@@ -1,15 +1,12 @@
 import styled from '@styles/themed-components';
-import Library from '@components/Template/Library/index.tsx';
+import Library from '@components/Template/Library';
 
 const MyTrack = () => (
-  <Library mainTitle={'믹스테잎'}>
-    <Container>
-      믹스테잎ㅍㅍㅍㅍ
-    </Container>
+  <Library mainTitle="믹스테잎">
+    <Container>믹스테잎ㅍㅍㅍㅍ</Container>
   </Library>
 );
 
-const Container = styled.div`
-`;
+const Container = styled.div``;
 
 export default MyTrack;

--- a/frontend/src/pages/Library/MyPlaylist/index.tsx
+++ b/frontend/src/pages/Library/MyPlaylist/index.tsx
@@ -1,15 +1,12 @@
 import styled from '@styles/themed-components';
-import Library from '@components/Template/Library/index.tsx';
+import Library from '@components/Template/Library';
 
 const MyArtist = () => (
-  <Library mainTitle={'플레이리스트'}>
-    <Container>
-      플레이리스트
-    </Container>
+  <Library mainTitle="플레이리스트">
+    <Container>플레이리스트</Container>
   </Library>
 );
 
-const Container = styled.div`
-`;
+const Container = styled.div``;
 
 export default MyArtist;

--- a/frontend/src/pages/Library/MyTrack/index.tsx
+++ b/frontend/src/pages/Library/MyTrack/index.tsx
@@ -1,5 +1,5 @@
 import styled from '@styles/themed-components';
-import Library from '@components/Template/Library/index.tsx';
+import Library from '@components/Template/Library';
 
 import TrackItem from '@components/Common/TrackItem';
 
@@ -8,7 +8,7 @@ const imgUrl =
 const artists = ['Tones And I'];
 
 const MyTrack = () => (
-  <Library mainTitle={'노래'} type={'track'}>
+  <Library mainTitle="노래" type="track">
     <Wrapper>
       <TrackItem
         type="checkBox"
@@ -20,9 +20,6 @@ const MyTrack = () => (
     </Wrapper>
   </Library>
 );
-
-const Container = styled.div`
-`;
 
 const Wrapper = styled.div`
   padding-bottom: 200px;


### PR DESCRIPTION
## 공유 사항
```
npm run dev에서는 정상 작동하나,
production환경에서의 npm run build, npm run start 명령어를 실행시 빌드 오류가 발생함
```

* BE
  - 빌드시 require 변수 이름이 겹쳐서 타입 선언 관련 충돌이 발생함!
tsconfig에 ``"typeRoots": [ "overrides", "node_modules / @ types" ],``  를 추가하니 해결되었음.
(출처 : https://medium.com/@elenasufieva/handling-type-declarations-clash-in-typescript-b05b10723f47)

* FE
  - Layout 타입 에러 해결
  - 사용하지 않은 value 삭제