### PR TITLE
이벤트 CoreData 저장 및 불러오기 구현

### DIFF
--- a/iOS/MiniVIBE/MiniVIBE.xcodeproj/project.pbxproj
+++ b/iOS/MiniVIBE/MiniVIBE.xcodeproj/project.pbxproj
@@ -48,6 +48,7 @@
 		DE3D6F8925640FE800C236EF /* HomeFooterView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE3D6F8825640FE800C236EF /* HomeFooterView.swift */; };
 		DE3D6F95256414EA00C236EF /* HomeNowSectionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE3D6F94256414EA00C236EF /* HomeNowSectionView.swift */; };
 		DE3EF6D2257361EC00A25B71 /* MusicPlayerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE3EF6D1257361EC00A25B71 /* MusicPlayerView.swift */; };
+		DE7516A025776F990054AFC6 /* DBRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE75169F25776F990054AFC6 /* DBRepository.swift */; };
 		DE8F52DA256D829500A7735F /* HomeVibeRecommendItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE8F52D9256D829500A7735F /* HomeVibeRecommendItem.swift */; };
 		DE8F52E0256D82AC00A7735F /* HomeVibeRecommendSectionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE8F52DF256D82AC00A7735F /* HomeVibeRecommendSectionView.swift */; };
 		DE8F52E4256D82C500A7735F /* HomeVibeRecommendItemView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE8F52E3256D82C500A7735F /* HomeVibeRecommendItemView.swift */; };
@@ -118,6 +119,7 @@
 		DE3D6F8825640FE800C236EF /* HomeFooterView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeFooterView.swift; sourceTree = "<group>"; };
 		DE3D6F94256414EA00C236EF /* HomeNowSectionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeNowSectionView.swift; sourceTree = "<group>"; };
 		DE3EF6D1257361EC00A25B71 /* MusicPlayerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MusicPlayerView.swift; sourceTree = "<group>"; };
+		DE75169F25776F990054AFC6 /* DBRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DBRepository.swift; sourceTree = "<group>"; };
 		DE8F52D9256D829500A7735F /* HomeVibeRecommendItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeVibeRecommendItem.swift; sourceTree = "<group>"; };
 		DE8F52DF256D82AC00A7735F /* HomeVibeRecommendSectionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeVibeRecommendSectionView.swift; sourceTree = "<group>"; };
 		DE8F52E3256D82C500A7735F /* HomeVibeRecommendItemView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeVibeRecommendItemView.swift; sourceTree = "<group>"; };
@@ -192,6 +194,7 @@
 		B994C69A25627DBD000E563C /* MiniVIBE */ = {
 			isa = PBXGroup;
 			children = (
+				DE75169E25776F8A0054AFC6 /* Repository */,
 				DEF5EFEC25727DF8006666DC /* Models */,
 				B9DB8A17256CFE0200D3F1A2 /* Common */,
 				B9D18FD8256CD61600ECEFEC /* HomeView */,
@@ -212,13 +215,6 @@
 				B994C6A225627DBE000E563C /* Preview Assets.xcassets */,
 			);
 			path = "Preview Content";
-			sourceTree = "<group>";
-		};
-		B9A0B377256E48AB00303F2F /* HomeRecentlyPlayedSongs */ = {
-			isa = PBXGroup;
-			children = (
-			);
-			path = HomeRecentlyPlayedSongs;
 			sourceTree = "<group>";
 		};
 		B9A156F7256E2EDA00FFDA20 /* HomeDJStationSection */ = {
@@ -267,7 +263,6 @@
 				B9DB8A23256D08FC00D3F1A2 /* HomeArtistSection */,
 				B9310174256D73A000DD5ADA /* HomePlayListSection */,
 				B9A156F7256E2EDA00FFDA20 /* HomeDJStationSection */,
-				B9A0B377256E48AB00303F2F /* HomeRecentlyPlayedSongs */,
 			);
 			path = HomeView;
 			sourceTree = "<group>";
@@ -350,6 +345,14 @@
 				DE35E2EC256D569500F369BE /* HomeNewAlbumItem.swift */,
 			);
 			path = HomeNewAlbum;
+			sourceTree = "<group>";
+		};
+		DE75169E25776F8A0054AFC6 /* Repository */ = {
+			isa = PBXGroup;
+			children = (
+				DE75169F25776F990054AFC6 /* DBRepository.swift */,
+			);
+			path = Repository;
 			sourceTree = "<group>";
 		};
 		DE8F52D8256D823B00A7735F /* HomeVibeRecommendSection */ = {
@@ -528,6 +531,7 @@
 				B9B4D1FF256E5CC300EC2FE2 /* HomeSummaryItemView.swift in Sources */,
 				B9B4D1F9256E5C8A00EC2FE2 /* Color+vibePink.swift in Sources */,
 				B9B4D1FA256E5C8A00EC2FE2 /* HomeSummarySectionView.swift in Sources */,
+				DE7516A025776F990054AFC6 /* DBRepository.swift in Sources */,
 				B9F0BDD4256EE031004A2852 /* ImageItemView.swift in Sources */,
 				B9B4D1F6256E5C7D00EC2FE2 /* HomeHeaderView.swift in Sources */,
 				DE35E2F7256D56BF00F369BE /* HomeNewAlbumSectionView.swift in Sources */,

--- a/iOS/MiniVIBE/MiniVIBE.xcodeproj/project.pbxproj
+++ b/iOS/MiniVIBE/MiniVIBE.xcodeproj/project.pbxproj
@@ -247,13 +247,6 @@
 			path = HomeDJStationSection;
 			sourceTree = "<group>";
 		};
-		B9A9FA76257613B700687EA1 /* Repositories */ = {
-			isa = PBXGroup;
-			children = (
-			);
-			path = Repositories;
-			sourceTree = "<group>";
-		};
 		B9B4D1E9256E5BAC00EC2FE2 /* View */ = {
 			isa = PBXGroup;
 			children = (
@@ -298,7 +291,6 @@
 		B9DB8A17256CFE0200D3F1A2 /* Common */ = {
 			isa = PBXGroup;
 			children = (
-				B9A9FA76257613B700687EA1 /* Repositories */,
 				B9B4D1E9256E5BAC00EC2FE2 /* View */,
 				B9DB8A18256CFE1C00D3F1A2 /* Extension */,
 			);

--- a/iOS/MiniVIBE/MiniVIBE/ContentView.swift
+++ b/iOS/MiniVIBE/MiniVIBE/ContentView.swift
@@ -9,37 +9,57 @@ import SwiftUI
 import CoreData
 
 struct ContentView: View {
+    @EnvironmentObject var viewModel: ViewModel
     var playingBar = NowPlayingBarView()
     var musicPlayer = MusicPlayer()
     var body: some View {
-        TabView {
+        TabView(selection: $viewModel.selectedTab) {
             HomeView(playingBar: playingBar)
                 .tabItem {
                     Image(systemName: "house")
-                }
-            Text("Another Tab")
-                .tabItem {
-                    Image(systemName: "chart.bar.doc.horizontal")
-                }
-            Text("The Last Tab")
-                .tabItem {
-                    Image(systemName: "play.rectangle.fill")
-                }
+                }.tag(0)
+            Button(action: {
+                viewModel.dbRepository.fetchEvent()
+            }, label: {
+                Text("fetch")
+            })
+            .tabItem {
+                Image(systemName: "chart.bar.doc.horizontal")
+            }.tag(1)
+            Button(action: {
+                viewModel.dbRepository.deleteAllEvent()
+            }, label: {
+                Text("delete")
+            })
+            .tabItem {
+                Image(systemName: "play.rectangle.fill")
+            }.tag(2)
             Text("Another Tab")
                 .tabItem {
                     Image(systemName: "magnifyingglass")
-                }
+                }.tag(3)
             Text("The Last Tab")
                 .tabItem {
                     Image(systemName: "person.fill")
-                }
+                }.tag(4)
         }.accentColor(.vibePink)
         .environmentObject(musicPlayer)
     }
 }
 
-struct ContentView_Previews: PreviewProvider {
-    static var previews: some View {
-        ContentView()
+extension ContentView {
+    class ViewModel: ObservableObject {
+        let dbRepository: DBRepository
+        @Published var selectedTab = 0 {
+            didSet {
+                let event = dbRepository.newEvent()
+                event.tab = Int32(selectedTab)
+                dbRepository.saveContext()
+            }
+        }
+        
+        init(dbRepository: DBRepository) {
+            self.dbRepository = dbRepository
+        }
     }
 }

--- a/iOS/MiniVIBE/MiniVIBE/MiniVIBE.xcdatamodeld/MiniVIBE.xcdatamodel/contents
+++ b/iOS/MiniVIBE/MiniVIBE/MiniVIBE.xcdatamodeld/MiniVIBE.xcdatamodel/contents
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="1" systemVersion="11A491" minimumToolsVersion="Automatic" sourceLanguage="Swift" usedWithCloudKit="false" userDefinedModelVersionIdentifier="">
-    <entity name="Item" representedClassName="Item" syncable="YES" codeGenerationType="class">
-        <attribute name="timestamp" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
+<model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="17511" systemVersion="20B50" minimumToolsVersion="Automatic" sourceLanguage="Swift" userDefinedModelVersionIdentifier="">
+    <entity name="Event" representedClassName="Event" syncable="YES" codeGenerationType="class">
+        <attribute name="tab" optional="YES" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="YES"/>
     </entity>
     <elements>
-        <element name="Item" positionX="-63" positionY="-18" width="128" height="44"/>
+        <element name="Event" positionX="-63" positionY="-18" width="128" height="44"/>
     </elements>
 </model>

--- a/iOS/MiniVIBE/MiniVIBE/MiniVIBEApp.swift
+++ b/iOS/MiniVIBE/MiniVIBE/MiniVIBEApp.swift
@@ -12,15 +12,10 @@ struct MiniVIBEApp: App {
     init() {
         UITabBar.appearance().barTintColor = .black
     }
+    let dbRepository = DBRepository()
     var body: some Scene {
         WindowGroup {
-            ContentView()
+            ContentView().environmentObject(ContentView.ViewModel(dbRepository: dbRepository))
         }
-    }
-}
-
-struct MiniVIBEApp_Previews: PreviewProvider {
-    static var previews: some View {
-        Text("Hello, World!")
     }
 }

--- a/iOS/MiniVIBE/MiniVIBE/Persistence.swift
+++ b/iOS/MiniVIBE/MiniVIBE/Persistence.swift
@@ -7,36 +7,60 @@
 
 import CoreData
 
-struct PersistenceController {
-    static let shared = PersistenceController()
-
-    static var preview: PersistenceController = {
-        let result = PersistenceController(inMemory: true)
-        let viewContext = result.container.viewContext
-        for _ in 0..<10 {
-            let newItem = Item(context: viewContext)
-            newItem.timestamp = Date()
-        }
-        do {
-            try viewContext.save()
-        } catch {
-            let nsError = error as NSError
-            fatalError("Unresolved error \(nsError), \(nsError.userInfo)")
-        }
-        return result
-    }()
-
-    let container: NSPersistentContainer
-
-    init(inMemory: Bool = false) {
-        container = NSPersistentContainer(name: "MiniVIBE")
-        if inMemory {
-            container.persistentStoreDescriptions.first!.url = URL(fileURLWithPath: "/dev/null")
-        }
-        container.loadPersistentStores(completionHandler: { (_, error) in
+class PersistenceController {
+    lazy var persistentContainer: NSPersistentContainer = {
+        let container = NSPersistentContainer(name: "MiniVIBE")
+        container.loadPersistentStores(completionHandler: { (storeDescription, error) in
             if let error = error as NSError? {
-                fatalError("Unresolved error \(error), \(error.userInfo)")
-            }
+                fatalError("Unresolved error \(error), \(error.userInfo)") }
         })
+        return container
+    }()
+    
+    var context: NSManagedObjectContext {
+        return persistentContainer.viewContext
+    }
+//
+//    func addEvent(event: Event) -> Bool {
+//        guard let entity = NSEntityDescription.entity(forEntityName: "Event", in: self.context) else { return false }
+//        let managedObject = NSManagedObject(entity: entity, insertInto: self.context)
+//        managedObject.setValue(event.tab, forKey: "tab")
+//        do {
+//            try self.context.save()
+//            return true
+//        } catch { print(error.localizedDescription)
+//            return false
+//        }
+//    }
+
+    func fetch() -> [Event] {
+        do {
+            let request: NSFetchRequest<Event> = Event.fetchRequest()
+            let fetchResult = try self.context.fetch(request)
+            return fetchResult
+        } catch {
+            print(error.localizedDescription)
+            return []
+        }
+    }
+
+    func deleteAll() -> Bool {
+        let request: NSFetchRequest<NSFetchRequestResult> = Event.fetchRequest()
+        let delete = NSBatchDeleteRequest(fetchRequest: request)
+        do {
+            try self.context.execute(delete)
+            return true
+        } catch {
+            return false
+        }
+    }
+    
+    func saveContext() -> Bool {
+        do {
+            try self.context.save()
+            return true
+        } catch { print(error.localizedDescription)
+            return false
+        }
     }
 }

--- a/iOS/MiniVIBE/MiniVIBE/Persistence.swift
+++ b/iOS/MiniVIBE/MiniVIBE/Persistence.swift
@@ -37,10 +37,10 @@ class PersistenceController {
         let delete = NSBatchDeleteRequest(fetchRequest: request)
         do {
             try self.context.execute(delete)
-            return true
         } catch {
             return false
         }
+        return true
     }
     
     func saveContext() -> Bool {

--- a/iOS/MiniVIBE/MiniVIBE/Persistence.swift
+++ b/iOS/MiniVIBE/MiniVIBE/Persistence.swift
@@ -20,19 +20,7 @@ class PersistenceController {
     var context: NSManagedObjectContext {
         return persistentContainer.viewContext
     }
-//
-//    func addEvent(event: Event) -> Bool {
-//        guard let entity = NSEntityDescription.entity(forEntityName: "Event", in: self.context) else { return false }
-//        let managedObject = NSManagedObject(entity: entity, insertInto: self.context)
-//        managedObject.setValue(event.tab, forKey: "tab")
-//        do {
-//            try self.context.save()
-//            return true
-//        } catch { print(error.localizedDescription)
-//            return false
-//        }
-//    }
-
+    
     func fetch() -> [Event] {
         do {
             let request: NSFetchRequest<Event> = Event.fetchRequest()
@@ -43,7 +31,7 @@ class PersistenceController {
             return []
         }
     }
-
+    
     func deleteAll() -> Bool {
         let request: NSFetchRequest<NSFetchRequestResult> = Event.fetchRequest()
         let delete = NSBatchDeleteRequest(fetchRequest: request)

--- a/iOS/MiniVIBE/MiniVIBE/Repository/DBRepository.swift
+++ b/iOS/MiniVIBE/MiniVIBE/Repository/DBRepository.swift
@@ -12,11 +12,6 @@ struct DBRepository: EnvironmentKey {
     
     let persistenceStore = PersistenceController()
     
-    //컴바인 적용해서 퍼블리셔로 바꿔야 할 수도 있음
-//    func addEvent(event: Event) {
-//        persistenceStore.addEvent(event: event)
-//    }
-//
     func fetchEvent() {
         let event = persistenceStore.fetch()
         event.forEach {

--- a/iOS/MiniVIBE/MiniVIBE/Repository/DBRepository.swift
+++ b/iOS/MiniVIBE/MiniVIBE/Repository/DBRepository.swift
@@ -7,9 +7,7 @@
 
 import SwiftUI
 
-struct DBRepository: EnvironmentKey {
-    static var defaultValue = DBRepository()
-    
+struct DBRepository {
     let persistenceStore = PersistenceController()
     
     func fetchEvent() {
@@ -33,11 +31,4 @@ struct DBRepository: EnvironmentKey {
         persistenceStore.saveContext()
     }
     
-}
-
-extension EnvironmentValues {
-    var dbRepository: DBRepository {
-        get { self[DBRepository.self] }
-        set { self[DBRepository.self] = newValue}
-    }
 }

--- a/iOS/MiniVIBE/MiniVIBE/Repository/DBRepository.swift
+++ b/iOS/MiniVIBE/MiniVIBE/Repository/DBRepository.swift
@@ -1,0 +1,48 @@
+//
+//  DBRepository.swift
+//  MiniVIBE
+//
+//  Created by GH Choi on 2020/12/02.
+//
+
+import SwiftUI
+
+struct DBRepository: EnvironmentKey {
+    static var defaultValue = DBRepository()
+    
+    let persistenceStore = PersistenceController()
+    
+    //컴바인 적용해서 퍼블리셔로 바꿔야 할 수도 있음
+//    func addEvent(event: Event) {
+//        persistenceStore.addEvent(event: event)
+//    }
+//
+    func fetchEvent() {
+        let event = persistenceStore.fetch()
+        event.forEach {
+            print($0.tab)
+        }
+    }
+    
+    func deleteAllEvent() {
+        let result = persistenceStore.deleteAll()
+        print(result ? "성공" : "실패")
+    }
+    
+    func newEvent() -> Event {
+        let event = Event(context: persistenceStore.context)
+        return event
+    }
+    
+    func saveContext() {
+        persistenceStore.saveContext()
+    }
+    
+}
+
+extension EnvironmentValues {
+    var dbRepository: DBRepository {
+        get { self[DBRepository.self] }
+        set { self[DBRepository.self] = newValue}
+    }
+}


### PR DESCRIPTION
보여지는 탭의 번호를 저장하는 간단한 이벤트 객체를 만들었습니다.
누를 때마다 코어데이터에 저장 후 가져오는 동작, 모두 비우는 동작을 버튼을 다른 탭의 구현해 확인했습니다.
일단 view model을 만들어 그 안에 DB레퍼지토리를 넣어놨는데 통합 레퍼지토리 레이어로의 통합이 필요하다고 생각됩니다.

![screenshot](https://user-images.githubusercontent.com/53948757/100862952-2e0aba00-34d7-11eb-8495-7686086ebb70.gif)


#66