### PR TITLE
[FE & BE] 로그인 버튼 임시 구현 & API 예외 처리 추가

### DIFF
--- a/backend/src/route/album/controller.ts
+++ b/backend/src/route/album/controller.ts
@@ -1,18 +1,15 @@
 import { Request, Response, NextFunction } from 'express';
 import Album from '../../entities/Album';
 
-const getAlbumByAlbumId = async (
-  req: Request,
-  res: Response,
-  next: NextFunction,
-): Promise<void> => {
+const getAlbumByAlbumId = async (req: Request, res: Response, next: NextFunction): Promise<any> => {
   try {
     const { albumId } = req.params;
     const album = await Album.findOne(albumId, { relations: ['genres', 'artists'] });
-    res.status(200).json({ success: true, data: album });
+    if (!album) return res.status(404).json({ message: 'Album Not Found' });
+    return res.status(200).json({ success: true, data: album });
   } catch (err) {
     console.log(err);
-    next(err);
+    return next(err);
   }
 };
 

--- a/backend/src/route/artist/controller.ts
+++ b/backend/src/route/artist/controller.ts
@@ -5,14 +5,15 @@ const getArtistByArtistId = async (
   req: Request,
   res: Response,
   next: NextFunction,
-): Promise<void> => {
+): Promise<any> => {
   try {
     const { artistId } = req.params;
     const artist = await Artist.findOne(artistId, { relations: ['genres'] });
-    res.status(200).json({ success: true, data: artist });
+    if (!artist) return res.status(404).json({ message: 'Artist Not Found' });
+    return res.status(200).json({ success: true, data: artist });
   } catch (err) {
     console.log(err);
-    next(err);
+    return next(err);
   }
 };
 

--- a/backend/src/route/auth/controller.ts
+++ b/backend/src/route/auth/controller.ts
@@ -8,7 +8,8 @@ const getToken = (req: Request, res: Response): void => {
     expiresIn: '1h',
     noTimestamp: true,
   });
-  res.json({ token });
+  res.cookie('token', token);
+  res.redirect(process.env.SERVICE_URL as string);
 };
 
 export { getToken };

--- a/backend/src/route/track/controller.ts
+++ b/backend/src/route/track/controller.ts
@@ -1,18 +1,15 @@
 import { Request, Response, NextFunction } from 'express';
 import Track from '../../entities/Track';
 
-const getTrackByTrackId = async (
-  req: Request,
-  res: Response,
-  next: NextFunction,
-): Promise<void> => {
+const getTrackByTrackId = async (req: Request, res: Response, next: NextFunction): Promise<any> => {
   try {
     const { trackId } = req.params;
     const track = await Track.findOne(trackId, { relations: ['album', 'artists'] });
-    res.status(200).json({ success: true, data: track });
+    if (!track) return res.status(404).json({ message: 'Track Not Found' });
+    return res.status(200).json({ success: true, data: track });
   } catch (err) {
     console.log(err);
-    next(err);
+    return next(err);
   }
 };
 

--- a/frontend/src/components/Layout/SideBar/NavBar/index.tsx
+++ b/frontend/src/components/Layout/SideBar/NavBar/index.tsx
@@ -6,9 +6,17 @@ import NavList from './NavList';
 const profileImgUrl =
   'https://phinf.pstatic.net/contact/20200707_134/1594090738223DUwwm_JPEG/20160913_143317.jpg?type=s33';
 
+const loginEvent = () => {
+  window.location.href = 'http://localhost:8000/api/auth/login';
+};
+
 function NavBar() {
   return (
     <Container>
+      <AuthWrapper onClick={loginEvent}>
+        <ProfileImg src={profileImgUrl} />
+        로그인
+      </AuthWrapper>
       <AuthWrapper>
         <ProfileImg src={profileImgUrl} />
         <Dropdown type="auth" />


### PR DESCRIPTION
### 구현 기능
<img width="206" alt="Screen Shot 2020-12-03 at 4 03 57 PM" src="https://user-images.githubusercontent.com/48378720/100975320-2dc6f900-3581-11eb-9e18-a5e7ff096c5b.png">

- FE: 네이버 아이디로 로그인 구현을 테스트하기 위해 임시로 사용할 버튼을 추가
- BE: JWT 토큰을 쿠키로 전달하고 홈으로 리디렉션
- BE: API 예외 처리 추가

### 논의 사항
- 로그인 상태를 어디서 관리할 지 고민
- 어디로 리디렉션할지 고민
- 클라이언트 환경 변수