### PR TITLE
[WEB] Playbar, Today 페이지 컴포넌트 UI 구현 & get/megazine API 구현

### DIFF
--- a/backend/src/route/artist/controller.ts
+++ b/backend/src/route/artist/controller.ts
@@ -17,4 +17,4 @@ const getArtistByArtistId = async (
   }
 };
 
-export { getArtistByArtistId };
+export default getArtistByArtistId;

--- a/backend/src/route/artist/index.ts
+++ b/backend/src/route/artist/index.ts
@@ -1,5 +1,5 @@
 import * as express from 'express';
-import { getArtistByArtistId } from './controller';
+import getArtistByArtistId from './controller';
 
 const route = express.Router();
 

--- a/backend/src/route/index.ts
+++ b/backend/src/route/index.ts
@@ -8,6 +8,7 @@ import trackRoute from './track';
 import albumRoute from './album';
 import artistRoute from './artist';
 import magRoute from './mag';
+import playlistRoute from './playlist';
 
 const route = express.Router();
 
@@ -19,6 +20,7 @@ route.use('/library', libraryRoute);
 route.use('/track', trackRoute);
 route.use('/album', albumRoute);
 route.use('/artist', artistRoute);
-route.use('/magazines', magRoute);
+route.use('/magazine', magRoute);
+route.use('/playlist', playlistRoute);
 
 export default route;

--- a/backend/src/route/playlist/controller.ts
+++ b/backend/src/route/playlist/controller.ts
@@ -1,0 +1,15 @@
+import { Request, Response, NextFunction } from 'express';
+import Playlist from '../../entities/Playlist';
+
+const getPlaylists = async (req: Request, res: Response, next: NextFunction): Promise<any> => {
+  try {
+    const playlist = await Playlist.find({ relations: ['tracks'] });
+    if (!playlist) return res.status(404).json({ message: 'Playlist Not Found' });
+    return res.status(200).json({ success: true, data: playlist });
+  } catch (err) {
+    console.log(err);
+    return next(err);
+  }
+};
+
+export default getPlaylists;

--- a/backend/src/route/playlist/index.ts
+++ b/backend/src/route/playlist/index.ts
@@ -1,0 +1,8 @@
+import * as express from 'express';
+import getPlaylists from './controller';
+
+const route = express.Router();
+
+route.get('/', getPlaylists);
+
+export default route;

--- a/frontend/pages/today.tsx
+++ b/frontend/pages/today.tsx
@@ -2,10 +2,13 @@ import useFetch from '@hooks/useFetch';
 import Today from '../src/pages/Today';
 
 function Index() {
-  const { data: mag, isLoading, isError } = useFetch(`/magazines`);
-  if (isLoading) return <div>...Loading</div>;
-  if (isError) {
-    console.log(isError);
+  const { data: mag, isLoading: magLoading, isError: magError } = useFetch(`/magazine`);
+  const { data: playlist, isLoading: playLoading, isError: playError } = useFetch(`/playlist`);
+
+  if (magLoading || playLoading) return <div>...Loading</div>;
+  if (magError || playError) {
+    console.log(magError);
+    console.log(playError);
     return <div>...Error</div>;
   }
 
@@ -15,7 +18,7 @@ function Index() {
 
   return (
     <div>
-      <Today magList={mag.data} />
+      <Today magList={mag.data} playlistList={playlist.data} />
     </div>
   );
 }

--- a/frontend/src/components/AlbumList/index.tsx
+++ b/frontend/src/components/AlbumList/index.tsx
@@ -19,6 +19,7 @@ const ListContainer = styled.div`
     auto-fill,
     minmax(${props => props.theme.size.smallCarouselContentWidth}, 1fr)
   );
+  grid-gap: 45px 0;
 `;
 
 export default AlbumList;

--- a/frontend/src/components/ArtistList/index.tsx
+++ b/frontend/src/components/ArtistList/index.tsx
@@ -19,6 +19,7 @@ const ListContainer = styled.div`
     auto-fill,
     minmax(${props => props.theme.size.smallCarouselContentWidth}, 1fr)
   );
+  grid-gap: 45px 0;
 `;
 
 export default ArtistList;

--- a/frontend/src/components/Common/BoxItem/index.tsx
+++ b/frontend/src/components/Common/BoxItem/index.tsx
@@ -17,6 +17,7 @@ function BoxItem({ imgUrl }) {
 
 const BoxImage = styled.img`
   width: 100%;
+  height: 100%;
 `;
 
 const ButtonsWrapper = styled.div`

--- a/frontend/src/components/Common/Card/AlbumCard/index.tsx
+++ b/frontend/src/components/Common/Card/AlbumCard/index.tsx
@@ -39,7 +39,6 @@ const AlbumCard = ({ albumMetaData }: IAlbumMetaProps) => {
 
 const Container = styled.ul`
   width: ${props => props.theme.size.smallCarouselContentWidth};
-  height: ${props => props.theme.size.smallCarouselContentWidth};
   display: flex;
   flex-direction: column;
   align-items: center;

--- a/frontend/src/components/Common/Card/ArtistCard/index.tsx
+++ b/frontend/src/components/Common/Card/ArtistCard/index.tsx
@@ -30,7 +30,6 @@ const ArtistCard = ({ artistMetaData }: IArtistMetaProps) => {
 
 const Container = styled.ul`
   width: ${props => props.theme.size.smallCarouselContentWidth};
-  height: ${props => props.theme.size.smallCarouselContentWidth};
   display: flex;
   flex-direction: column;
   align-items: center;

--- a/frontend/src/components/Common/Card/MagCard/index.tsx
+++ b/frontend/src/components/Common/Card/MagCard/index.tsx
@@ -32,7 +32,6 @@ const MagCard = ({ magMetaData: mag }: IMagMetaProps) => {
 
 const Container = styled.ul`
   width: ${props => props.theme.size.smallCarouselContentWidth};
-  height: ${props => props.theme.size.smallCarouselContentWidth};
   display: flex;
   flex-direction: column;
   align-items: center;

--- a/frontend/src/components/Common/Card/MagCard/index.tsx
+++ b/frontend/src/components/Common/Card/MagCard/index.tsx
@@ -31,10 +31,9 @@ const MagCard = ({ magMetaData: mag }: IMagMetaProps) => {
 };
 
 const Container = styled.ul`
-  width: ${props => props.theme.size.smallCarouselContentWidth};
+  width: ${props => props.theme.size.bigCarouselContentWidth};
   display: flex;
   flex-direction: column;
-  align-items: center;
 `;
 
 const MagTitle = styled.a`

--- a/frontend/src/components/Common/Card/PlaylistCard/index.tsx
+++ b/frontend/src/components/Common/Card/PlaylistCard/index.tsx
@@ -32,7 +32,6 @@ const AlbumCard = ({ playlistMetaData: playlist }: IPlaylistMetaProps) => {
 
 const Container = styled.ul`
   width: ${props => props.theme.size.smallCarouselContentWidth};
-  height: ${props => props.theme.size.smallCarouselContentWidth};
   display: flex;
   flex-direction: column;
   align-items: center;

--- a/frontend/src/components/Common/Carousel/index.tsx
+++ b/frontend/src/components/Common/Carousel/index.tsx
@@ -41,7 +41,7 @@ const Wrapper = styled.div`
     width: 40px;
     height: 40px;
     position: absolute;
-    top: 30%;
+    top: 35%;
     border-radius: 50%;
     opacity: 100%;
   }

--- a/frontend/src/components/Common/Carousel/index.tsx
+++ b/frontend/src/components/Common/Carousel/index.tsx
@@ -1,6 +1,10 @@
 import Carousel from 'react-bootstrap/Carousel';
 import styled from '@styles/themed-components';
 
+interface CarouselWrapperProps {
+  groupSize?: number;
+}
+
 const MyCarousel = ({ children, groupSize }) => {
   const rows = children
     .map(card => <>{card}</>)
@@ -11,7 +15,9 @@ const MyCarousel = ({ children, groupSize }) => {
     }, [])
     .map(rowContent => (
       <Carousel.Item key={rowContent.id}>
-        <ContentWrapper>{rowContent}</ContentWrapper>
+        <ContentWrapper className="carousel-content-wrapper" groupSize={groupSize}>
+          {rowContent}
+        </ContentWrapper>
       </Carousel.Item>
     ));
   return (
@@ -23,11 +29,15 @@ const MyCarousel = ({ children, groupSize }) => {
   );
 };
 
-const ContentWrapper = styled.div`
+const ContentWrapper = styled.div<CarouselWrapperProps>`
   width: 100%;
   display: flex;
   padding: 20px 0;
-  justify-content: space-between;
+  justify-content: flex-start;
+  display: grid;
+  grid-template-columns: ${props =>
+    props.groupSize === 3 ? 'repeat(3, 300px)' : 'repeat(5, 180px)'};
+  grid-column-gap: 30px;
 `;
 
 const Wrapper = styled.div`

--- a/frontend/src/components/Common/MagTag/index.tsx
+++ b/frontend/src/components/Common/MagTag/index.tsx
@@ -1,0 +1,58 @@
+import React from 'react';
+import styled from 'styled-components';
+
+function MagTag({ type }) {
+  switch (type) {
+    case 'special':
+      return (
+        <SpecialTag>
+          <TagText>SPECIAL</TagText>
+        </SpecialTag>
+      );
+    case 'pick':
+      return (
+        <PickTag>
+          <TagText>PICK</TagText>
+        </PickTag>
+      );
+    case 'genre':
+      return (
+        <GenreTag>
+          <TagText>GENRE</TagText>
+        </GenreTag>
+      );
+    default:
+      return (
+        <All>
+          <TagText>전체</TagText>
+        </All>
+      );
+  }
+}
+
+const TagText = styled.span`
+  font-size: 13px;
+  font-weight: 600;
+  font-style: italic;
+  position: relative;
+  bottom: 1px;
+  color: ${props => props.theme.color.white};
+`;
+
+const All = styled.a`
+  padding: 5px 16px;
+  border-radius: 30px;
+  background: ${props => props.theme.color.highlight};
+`;
+
+const SpecialTag = styled(All)`
+  background: linear-gradient(to right, red, #ff00a0, #7e00e4);
+`;
+
+const PickTag = styled(All)``;
+
+const GenreTag = styled(All)`
+  background: #7e00e4;
+`;
+
+export default MagTag;

--- a/frontend/src/components/Common/MagTopItem/index.tsx
+++ b/frontend/src/components/Common/MagTopItem/index.tsx
@@ -1,14 +1,39 @@
 import React from 'react';
 import styled from 'styled-components';
 
+const testUrl =
+  'https://music-phinf.pstatic.net/20201204_48/1607059391554q6R0k_JPEG/1204_mushvenom_magazine_cover.jpg?type=w720';
+
 function MagTopItem() {
-  return <Wrapper />;
+  return (
+    <Wrapper>
+      <MagImg src={testUrl} alt="mag-top-img" />
+      <MagContent>
+        <h1>안녕하세요ㅠㅠㅎㄴ란ㅇㄹ</h1>
+        <h3>안녕하세요ㅠㅠㅎㄴ란ㅇㄹ</h3>
+        <p>안녕하세요ㅠㅠㅎㄴ란ㅇㄹ</p>
+      </MagContent>
+    </Wrapper>
+  );
 }
 
-const Wrapper = styled.div`
+const MagImg = styled.img`
+  height: ${props => props.theme.size.magTopItemHeight};
+  display: flex;
+`;
+
+const MagContent = styled.div`
+  background: gold;
   width: 100%;
-  height: 320px;
+  padding: 40px;
+`;
+
+const Wrapper = styled.div`
+  width: ${props => props.theme.size.mainContentWidth};
+  margin: 0 auto;
+  height: ${props => props.theme.size.magTopItemHeight};
   background-color: white;
+  display: flex;
 `;
 
 export default MagTopItem;

--- a/frontend/src/components/Common/MagTopItem/index.tsx
+++ b/frontend/src/components/Common/MagTopItem/index.tsx
@@ -1,31 +1,54 @@
 import React from 'react';
 import styled from 'styled-components';
+import trimContentLength from '@utils/trimContentLength';
+import MagTag from '@components/Common/MagTag';
+import BoxItem from '@components/Common/BoxItem';
 
-const testUrl =
-  'https://music-phinf.pstatic.net/20201204_48/1607059391554q6R0k_JPEG/1204_mushvenom_magazine_cover.jpg?type=w720';
-
-function MagTopItem() {
+function MagTopItem({ magData: mag }) {
   return (
     <Wrapper>
-      <MagImg src={testUrl} alt="mag-top-img" />
-      <MagContent>
-        <h1>안녕하세요ㅠㅠㅎㄴ란ㅇㄹ</h1>
-        <h3>안녕하세요ㅠㅠㅎㄴ란ㅇㄹ</h3>
-        <p>안녕하세요ㅠㅠㅎㄴ란ㅇㄹ</p>
-      </MagContent>
+      <ImgWrapper>
+        <BoxItem imgUrl={mag.imgUrl} />
+      </ImgWrapper>
+      <MagContentWrapper>
+        <TagWrapper>
+          <MagTag type={mag.tag} />
+        </TagWrapper>
+        <MagTitle>{mag.title}</MagTitle>
+        <MagContent>{trimContentLength(mag.content, 110)}</MagContent>
+        <MagContent>{`VIBE MAG · ${mag.date}`}</MagContent>
+      </MagContentWrapper>
     </Wrapper>
   );
 }
 
-const MagImg = styled.img`
+const ImgWrapper = styled.div`
+  width: ${props => props.theme.size.magTopItemHeight};
   height: ${props => props.theme.size.magTopItemHeight};
-  display: flex;
 `;
 
-const MagContent = styled.div`
-  background: gold;
-  width: 100%;
-  padding: 40px;
+const TagWrapper = styled.div`
+  margin-bottom: 24px;
+`;
+
+const MagTitle = styled.a`
+  ${props => props.theme.font.bigBoldTitle}
+`;
+
+const MagContentWrapper = styled.div`
+  background: white;
+  width: 640px;
+  padding: 55px;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+`;
+
+const MagContent = styled.p`
+  ${props => props.theme.font.sub}
+  font-size: 14px;
+  margin-top: 10px;
+  line-height: 130%;
 `;
 
 const Wrapper = styled.div`

--- a/frontend/src/components/Common/PlayTrackItem/index.tsx
+++ b/frontend/src/components/Common/PlayTrackItem/index.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import styled from 'styled-components';
-import { IoHeart, IoHeartOutline } from 'react-icons/io5';
+import { IoHeartOutline } from 'react-icons/io5';
 import { RiPlayListLine } from 'react-icons/ri';
 import { BsThreeDots } from 'react-icons/bs';
 

--- a/frontend/src/components/Common/PlayTrackItem/index.tsx
+++ b/frontend/src/components/Common/PlayTrackItem/index.tsx
@@ -1,0 +1,73 @@
+import React from 'react';
+import styled from 'styled-components';
+import { IoHeart, IoHeartOutline } from 'react-icons/io5';
+import { RiPlayListLine } from 'react-icons/ri';
+import { BsThreeDots } from 'react-icons/bs';
+
+const testImgUrl =
+  'https://musicmeta-phinf.pstatic.net/album/005/064/5064543.jpg?type=r720Fll&v=20201104164506';
+
+function PlayTrackItem() {
+  return (
+    <TrackWrapper>
+      <TrackImgWrapper>
+        <TrackImg src={testImgUrl} alt="playbar-track-img" />
+      </TrackImgWrapper>
+      <TrackContentWrapper>
+        <TrackTitle>얘랑 있을 때 좋다 (...</TrackTitle>
+        <TrackArtist>어쿠스틱 콜라보</TrackArtist>
+      </TrackContentWrapper>
+      <IconWrapper>
+        <IoHeartOutline className="like button" size={24} />
+        <RiPlayListLine className="lyric button" size={20} />
+        <BsThreeDots className="dropdown button" size={20} />
+      </IconWrapper>
+    </TrackWrapper>
+  );
+}
+
+const TrackImgWrapper = styled.a``;
+
+const TrackImg = styled.img`
+  width: 45px;
+  height: 45px;
+`;
+
+const TrackContentWrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+  padding-left: 12px;
+`;
+
+const TrackTitle = styled.a`
+  font-weight: 600;
+  font-size: 14px;
+  color: ${props => props.theme.color.white};
+`;
+
+const TrackArtist = styled.a`
+  font-size: 12px;
+  margin-top: 8px;
+  color: ${props => props.theme.color.playbarFontColor};
+`;
+
+const IconWrapper = styled.div`
+  width: 115px;
+  padding-left: 20px;
+  display: flex;
+  justify-content: space-between;
+  .icon:hover {
+    color: ${props => props.theme.color.white};
+  }
+`;
+
+const TrackWrapper = styled.div`
+  padding-left: 18px;
+  min-width: 350px;
+  height: 100%;
+  display: flex;
+  align-items: center;
+  color: ${props => props.theme.color.playbarFontColor};
+`;
+
+export default PlayTrackItem;

--- a/frontend/src/components/Common/Section/index.tsx
+++ b/frontend/src/components/Common/Section/index.tsx
@@ -7,7 +7,7 @@ const Section = ({ children }) => {
 
 const Wrapper = styled.div`
   width: 100%;
-  padding: 20px 0 32px 0;
+  padding: 24px 0 30px 0;
   border-bottom: 1px solid ${props => props.theme.color.borderColor};
   .section-title {
     ${props => props.theme.font.secTitle}

--- a/frontend/src/components/Layout/PlayBar/index.tsx
+++ b/frontend/src/components/Layout/PlayBar/index.tsx
@@ -7,7 +7,7 @@ import {
   IoShuffleOutline,
   IoRepeat,
 } from 'react-icons/io5';
-import { BsFillVolumeUpFill, BsFillVolumeMuteFill, BsMusicNoteList } from 'react-icons/bs';
+import { BsFillVolumeUpFill, BsMusicNoteList } from 'react-icons/bs';
 import PlayTrackItem from '@components/Common/PlayTrackItem';
 
 function PlayBar() {

--- a/frontend/src/components/Layout/PlayBar/index.tsx
+++ b/frontend/src/components/Layout/PlayBar/index.tsx
@@ -1,27 +1,174 @@
 import React from 'react';
 import styled from 'styled-components';
-import axios from 'axios';
+import {
+  IoPlaySkipForwardSharp,
+  IoPlaySkipBackSharp,
+  IoPlaySharp,
+  IoShuffleOutline,
+  IoRepeat,
+  IoHeart,
+  IoHeartOutline,
+} from 'react-icons/io5';
+import {
+  BsFillVolumeUpFill,
+  BsFillVolumeMuteFill,
+  BsMusicNoteList,
+  BsThreeDots,
+} from 'react-icons/bs';
+import { RiPlayListLine } from 'react-icons/ri';
 
-const eventHandler = () => {
-  axios
-    .post('http://localhost:8000/api/log', { eventType: 'clickPlaybar', userAge: 24 })
-    .then(res => {
-      console.log(res.data);
-    });
-};
+// const eventHandler = () => {
+//   axios
+//     .post('http://localhost:8000/api/log', { eventType: 'clickPlaybar', userAge: 24 })
+//     .then(res => {
+//       console.log(res.data);
+//     });
+// };
+
+const testImgUrl =
+  'https://musicmeta-phinf.pstatic.net/album/005/064/5064543.jpg?type=r720Fll&v=20201104164506';
 
 function PlayBar() {
-  return <Player onClick={eventHandler}>playbar</Player>;
+  return (
+    <Player>
+      <TrackWrapper>
+        <TrackImgWrapper>
+          <TrackImg src={testImgUrl} alt="playbar-track-img" />
+        </TrackImgWrapper>
+        <TrackContentWrapper>
+          <TrackTitle>얘랑 있을 때 좋다 (...</TrackTitle>
+          <TrackArtist>어쿠스틱 콜라보</TrackArtist>
+        </TrackContentWrapper>
+        <IconWrapper>
+          <IoHeartOutline className="like button" size={24} />
+          <RiPlayListLine className="lyric button" size={20} />
+          <BsThreeDots className="dropdown button" size={20} />
+        </IconWrapper>
+      </TrackWrapper>
+      <ButtonWrapper>
+        <IoShuffleOutline className="side button" size={26} />
+        <IoPlaySkipBackSharp className="skip button" size={22} />
+        <IoPlaySharp className="play button" size={35} />
+        <IoPlaySkipForwardSharp className="skip button" size={22} />
+        <IoRepeat className="side button" size={26} />
+      </ButtonWrapper>
+      <ListWrapper>
+        <TrackPlayTime>00:24 / 03:21</TrackPlayTime>
+        <VolumeBar>
+          <BsFillVolumeUpFill size={20} />
+          <VolumeStatusBar />
+        </VolumeBar>
+        <ListUpButton>
+          <BsMusicNoteList size={28} />
+        </ListUpButton>
+      </ListWrapper>
+    </Player>
+  );
 }
+
+const TrackPlayTime = styled.p`
+  font-size: 12px;
+`;
+const VolumeBar = styled.div`
+  display: flex;
+  align-items: center;
+`;
+
+const VolumeStatusBar = styled.div`
+  width: 100px;
+  height: 3px;
+  margin-left: 4px;
+  background: ${props => props.theme.color.grey};
+`;
+const ListUpButton = styled.button`
+  height: 100%;
+  width: ${props => props.theme.size.playbarheight};
+  border-left: 1px solid ${props => props.theme.color.grey};
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: ${props => props.theme.color.playbarFontColor};
+`;
+
+const TrackImgWrapper = styled.a``;
+
+const TrackImg = styled.img`
+  width: 45px;
+  height: 45px;
+`;
+
+const TrackContentWrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+  padding-left: 12px;
+`;
+
+const TrackTitle = styled.a`
+  font-weight: 600;
+  font-size: 14px;
+  color: ${props => props.theme.color.white};
+`;
+
+const TrackArtist = styled.a`
+  font-size: 12px;
+  margin-top: 8px;
+  color: ${props => props.theme.color.playbarFontColor};
+`;
+
+const IconWrapper = styled.div`
+  width: 115px;
+  padding-left: 20px;
+  display: flex;
+  justify-content: space-between;
+  .icon:hover {
+    color: ${props => props.theme.color.white};
+  }
+`;
+
+const ButtonWrapper = styled.div`
+  min-width: 240px;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  .skip {
+    color: ${props => props.theme.color.white};
+  }
+  .side {
+    color: ${props => props.theme.color.grey};
+  }
+  .play {
+    color: ${props => props.theme.color.highlight};
+  }
+`;
+
+const TrackWrapper = styled.div`
+  padding-left: 18px;
+  min-width: 350px;
+  height: 100%;
+  display: flex;
+  align-items: center;
+  color: ${props => props.theme.color.playbarFontColor};
+`;
+
+const ListWrapper = styled(TrackWrapper)`
+  justify-content: space-between;
+`;
 
 const Player = styled.div`
   position: fixed;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+
   right: 0;
   bottom: 0;
   left: 0;
   z-index: 10400;
-  height: 81px;
+  height: ${props => props.theme.size.playbarheight};
   background-color: rgba(25, 25, 25, 0.97);
+  .button {
+    cursor: pointer;
+  }
 `;
 
 export default PlayBar;

--- a/frontend/src/components/Layout/PlayBar/index.tsx
+++ b/frontend/src/components/Layout/PlayBar/index.tsx
@@ -6,45 +6,14 @@ import {
   IoPlaySharp,
   IoShuffleOutline,
   IoRepeat,
-  IoHeart,
-  IoHeartOutline,
 } from 'react-icons/io5';
-import {
-  BsFillVolumeUpFill,
-  BsFillVolumeMuteFill,
-  BsMusicNoteList,
-  BsThreeDots,
-} from 'react-icons/bs';
-import { RiPlayListLine } from 'react-icons/ri';
-
-// const eventHandler = () => {
-//   axios
-//     .post('http://localhost:8000/api/log', { eventType: 'clickPlaybar', userAge: 24 })
-//     .then(res => {
-//       console.log(res.data);
-//     });
-// };
-
-const testImgUrl =
-  'https://musicmeta-phinf.pstatic.net/album/005/064/5064543.jpg?type=r720Fll&v=20201104164506';
+import { BsFillVolumeUpFill, BsFillVolumeMuteFill, BsMusicNoteList } from 'react-icons/bs';
+import PlayTrackItem from '@components/Common/PlayTrackItem';
 
 function PlayBar() {
   return (
     <Player>
-      <TrackWrapper>
-        <TrackImgWrapper>
-          <TrackImg src={testImgUrl} alt="playbar-track-img" />
-        </TrackImgWrapper>
-        <TrackContentWrapper>
-          <TrackTitle>얘랑 있을 때 좋다 (...</TrackTitle>
-          <TrackArtist>어쿠스틱 콜라보</TrackArtist>
-        </TrackContentWrapper>
-        <IconWrapper>
-          <IoHeartOutline className="like button" size={24} />
-          <RiPlayListLine className="lyric button" size={20} />
-          <BsThreeDots className="dropdown button" size={20} />
-        </IconWrapper>
-      </TrackWrapper>
+      <PlayTrackItem />
       <ButtonWrapper>
         <IoShuffleOutline className="side button" size={26} />
         <IoPlaySkipBackSharp className="skip button" size={22} />
@@ -90,41 +59,6 @@ const ListUpButton = styled.button`
   color: ${props => props.theme.color.playbarFontColor};
 `;
 
-const TrackImgWrapper = styled.a``;
-
-const TrackImg = styled.img`
-  width: 45px;
-  height: 45px;
-`;
-
-const TrackContentWrapper = styled.div`
-  display: flex;
-  flex-direction: column;
-  padding-left: 12px;
-`;
-
-const TrackTitle = styled.a`
-  font-weight: 600;
-  font-size: 14px;
-  color: ${props => props.theme.color.white};
-`;
-
-const TrackArtist = styled.a`
-  font-size: 12px;
-  margin-top: 8px;
-  color: ${props => props.theme.color.playbarFontColor};
-`;
-
-const IconWrapper = styled.div`
-  width: 115px;
-  padding-left: 20px;
-  display: flex;
-  justify-content: space-between;
-  .icon:hover {
-    color: ${props => props.theme.color.white};
-  }
-`;
-
 const ButtonWrapper = styled.div`
   min-width: 240px;
   display: flex;
@@ -141,16 +75,13 @@ const ButtonWrapper = styled.div`
   }
 `;
 
-const TrackWrapper = styled.div`
+const ListWrapper = styled.div`
   padding-left: 18px;
   min-width: 350px;
   height: 100%;
   display: flex;
   align-items: center;
   color: ${props => props.theme.color.playbarFontColor};
-`;
-
-const ListWrapper = styled(TrackWrapper)`
   justify-content: space-between;
 `;
 

--- a/frontend/src/components/Layout/SideBar/Header/index.tsx
+++ b/frontend/src/components/Layout/SideBar/Header/index.tsx
@@ -1,13 +1,16 @@
 import React from 'react';
 import styled from '@styles/themed-components';
 import { CgSearch } from 'react-icons/cg';
+import Link from 'next/link';
 import Image from 'next/image';
 
 function Header() {
   return (
     <Container>
       <ImageWrapper>
-        <Image alt="header-logo" src="/images/header-logo.png" width={125} height={45} />
+        <Link href="/today">
+          <Image alt="header-logo" src="/images/header-logo.png" width={125} height={45} />
+        </Link>
       </ImageWrapper>
       <IconWrapper>
         <CgSearch size="26" className="search-icon" />

--- a/frontend/src/components/Layout/SideBar/NavBar/NavList/index.tsx
+++ b/frontend/src/components/Layout/SideBar/NavBar/NavList/index.tsx
@@ -1,7 +1,8 @@
 import React from 'react';
 import Link from 'next/link';
 import styled from '@styles/themed-components';
-import { FaBookOpen, FaMusic, FaTrophy, FaRecordVinyl, FaRegCalendar } from 'react-icons/fa';
+import { FaMusic } from 'react-icons/fa';
+// import { FaBookOpen, FaMusic, FaTrophy, FaRecordVinyl, FaRegCalendar } from 'react-icons/fa';
 import { useRouter } from 'next/router';
 
 interface NavItemProps {

--- a/frontend/src/components/Layout/SideBar/NavBar/NavList/index.tsx
+++ b/frontend/src/components/Layout/SideBar/NavBar/NavList/index.tsx
@@ -76,6 +76,7 @@ const LibraryTag = styled.span`
 const ItemText = styled.span`
   margin-left: 9px;
   position: relative;
+  top: 2px;
 `;
 
 const NavItemWrapper = styled.ul`
@@ -87,8 +88,6 @@ const NavItem = styled.li<NavItemProps>`
     props.isSelected ? `${props.theme.color.highlight}` : `${props.theme.color.headerNavColor}`};
   margin: 20px 0;
   cursor: pointer;
-  display: flex;
-  align-items: flex-start;
   font-weight: 500;
   &:hover {
     filter: ${props => (props.isSelected ? 'brightness(80%)' : 'brightness(120%)')};

--- a/frontend/src/components/Layout/SideBar/NavBar/NavList/index.tsx
+++ b/frontend/src/components/Layout/SideBar/NavBar/NavList/index.tsx
@@ -2,58 +2,64 @@ import React from 'react';
 import Link from 'next/link';
 import styled from '@styles/themed-components';
 import { FaBookOpen, FaMusic, FaTrophy, FaRecordVinyl, FaRegCalendar } from 'react-icons/fa';
+import { useRouter } from 'next/router';
+
+interface NavItemProps {
+  isSelected?: boolean;
+}
 
 function NavList() {
+  const router = useRouter();
   return (
     <Container>
       <NavItemWrapper>
         <Link href="/today">
-          <NavItem>
-            <FaMusic />
+          <NavItem isSelected={router.pathname === '/today'}>
+            <FaMusic size={18} />
             <ItemText>투데이</ItemText>
           </NavItem>
         </Link>
-        <Link href="/chart">
-          <NavItem>
-            <FaTrophy />
+        {/* <Link href="/chart">
+          <NavItem isSelected={router.pathname === '/chart'}>
+            <FaTrophy size={18} />
             <ItemText>차트</ItemText>
           </NavItem>
         </Link>
         <Link href="/dj-station">
-          <NavItem>
-            <FaRecordVinyl />
+          <NavItem isSelected={router.pathname === '/dj-station'}>
+            <FaRecordVinyl size={18} />
             <ItemText>DJ 스테이션</ItemText>
           </NavItem>
         </Link>
         <Link href="/magazines">
-          <NavItem>
-            <FaBookOpen />
+          <NavItem isSelected={router.pathname === '/magazines'}>
+            <FaBookOpen size={18} />
             <ItemText>VIBE MAG</ItemText>
           </NavItem>
         </Link>
         <Link href="/playlist">
-          <NavItem>
-            <FaRegCalendar />
+          <NavItem isSelected={router.pathname === '/playlist'}>
+            <FaRegCalendar size={18} />
             <ItemText>이달의 노래</ItemText>
           </NavItem>
-        </Link>
+        </Link> */}
       </NavItemWrapper>
       <NavItemWrapper>
         <LibraryTag>보관함</LibraryTag>
         <Link href="/library/mixtapes">
-          <NavItem>믹스테잎</NavItem>
+          <NavItem isSelected={router.pathname === '/library/mixtapes'}>믹스테잎</NavItem>
         </Link>
         <Link href="/library/tracks">
-          <NavItem>노래</NavItem>
+          <NavItem isSelected={router.pathname === '/library/tracks'}>노래</NavItem>
         </Link>
         <Link href="/library/artists">
-          <NavItem>아티스트</NavItem>
+          <NavItem isSelected={router.pathname === '/library/artists'}>아티스트</NavItem>
         </Link>
         <Link href="/library/albums">
-          <NavItem>앨범</NavItem>
+          <NavItem isSelected={router.pathname === '/library/albums'}>앨범</NavItem>
         </Link>
         <Link href="/library/playlists">
-          <NavItem>플레이리스트</NavItem>
+          <NavItem isSelected={router.pathname === '/library/playlists'}>플레이리스트</NavItem>
         </Link>
       </NavItemWrapper>
     </Container>
@@ -68,20 +74,24 @@ const LibraryTag = styled.span`
 `;
 
 const ItemText = styled.span`
-  margin-left: 10px;
+  margin-left: 9px;
   position: relative;
-  bottom: 3px;
 `;
 
 const NavItemWrapper = styled.ul`
   padding-top: 16px;
 `;
 
-const NavItem = styled.li`
+const NavItem = styled.li<NavItemProps>`
+  color: ${props =>
+    props.isSelected ? `${props.theme.color.highlight}` : `${props.theme.color.headerNavColor}`};
   margin: 20px 0;
   cursor: pointer;
+  display: flex;
+  align-items: flex-start;
+  font-weight: 500;
   &:hover {
-    color: ${props => props.theme.color.white};
+    filter: ${props => (props.isSelected ? 'brightness(80%)' : 'brightness(120%)')};
   }
 `;
 

--- a/frontend/src/components/Layout/index.tsx
+++ b/frontend/src/components/Layout/index.tsx
@@ -32,11 +32,6 @@ const Container = styled.div`
 `;
 
 // todaypage 빼고 다 max-width 964임.
-const Content = styled.div`
-  position: relative;
-  max-width: 1060px;
-  padding: 0 43px;
-  margin: auto;
-`;
+const Content = styled.div``;
 
 export default Layout;

--- a/frontend/src/components/PlaylistList/index.tsx
+++ b/frontend/src/components/PlaylistList/index.tsx
@@ -19,6 +19,7 @@ const ListContainer = styled.div`
     auto-fill,
     minmax(${props => props.theme.size.smallCarouselContentWidth}, 1fr)
   );
+  grid-gap: 45px 0;
 `;
 
 export default PlaylistList;

--- a/frontend/src/components/Template/Content/index.tsx
+++ b/frontend/src/components/Template/Content/index.tsx
@@ -1,0 +1,19 @@
+import React, { ReactElement } from 'react';
+import styled from '@styles/themed-components';
+
+interface IContent {
+  children: any;
+}
+
+// title이라고 하면 _document랑 충돌남
+function Content({ children }: IContent): ReactElement {
+  return <Wrapper>{children}</Wrapper>;
+}
+
+const Wrapper = styled.div`
+  position: relative;
+  max-width: ${props => props.theme.size.mainContentWidth};
+  margin: auto;
+`;
+
+export default Content;

--- a/frontend/src/components/Template/Detail/index.tsx
+++ b/frontend/src/components/Template/Detail/index.tsx
@@ -39,9 +39,11 @@ const HeaderImg = styled.img`
 `;
 
 const Wrapper = styled.div`
-  width: 100%;
   padding-top: 41px;
   padding-bottom: 23px;
+  margin: auto;
+  position: relative;
+  max-width: ${props => props.theme.size.mainContentWidth};
   margin: auto;
 `;
 

--- a/frontend/src/components/Template/Library/index.tsx
+++ b/frontend/src/components/Template/Library/index.tsx
@@ -35,6 +35,9 @@ const Wrapper = styled.div`
   padding-top: 41px;
   padding-bottom: 23px;
   margin: auto;
+  position: relative;
+  max-width: ${props => props.theme.size.mainContentWidth};
+  margin: auto;
 `;
 
 const Header = styled.header`

--- a/frontend/src/pages/DJStation/index.tsx
+++ b/frontend/src/pages/DJStation/index.tsx
@@ -15,8 +15,4 @@ const TopWrapper = styled.div`
   background-color: ${props => props.theme.color.lightgrey};
 `;
 
-const Wrapper = styled.div`
-  padding-bottom: 200px;
-`;
-
 export default DJStation;

--- a/frontend/src/pages/DJStation/index.tsx
+++ b/frontend/src/pages/DJStation/index.tsx
@@ -1,14 +1,11 @@
 import React from 'react';
 import styled from '@styles/themed-components';
-import MagTopItem from '@components/Common/MagTopItem';
 import Content from '@components/Template/Content';
 
 function DJStation() {
   return (
     <Content>
-      <TopWrapper>
-        <MagTopItem />
-      </TopWrapper>
+      <TopWrapper />
     </Content>
   );
 }

--- a/frontend/src/pages/DJStation/index.tsx
+++ b/frontend/src/pages/DJStation/index.tsx
@@ -1,14 +1,15 @@
 import React from 'react';
 import styled from '@styles/themed-components';
 import MagTopItem from '@components/Common/MagTopItem';
+import Content from '@components/Template/Content';
 
 function DJStation() {
   return (
-    <Wrapper>
+    <Content>
       <TopWrapper>
         <MagTopItem />
       </TopWrapper>
-    </Wrapper>
+    </Content>
   );
 }
 

--- a/frontend/src/pages/Today/index.tsx
+++ b/frontend/src/pages/Today/index.tsx
@@ -4,32 +4,34 @@ import Carousel from '@components/Common/Carousel';
 import Section from '@components/Common/Section';
 import MagCard from '@components/Common/Card/MagCard';
 import MagTopItem from '@components/Common/MagTopItem';
+import PlaylistCard from '@components/Common/Card/PlaylistCard';
+import { GrNext } from 'react-icons/gr';
+import useFetch from '../../hooks/useFetch';
 
-function Today({ magList }) {
+function Today({ magList, playlistList }) {
+  console.log('###', playlistList);
   return (
     <Wrapper>
-      <Black>
-        <MagTopItem />
-      </Black>
+      <MagTopWrapper>
+        <MagTopItem magData={magList[0]} />
+      </MagTopWrapper>
       <Content>
         <Section>
           <a className="section-title">매거진</a>
+
           <Carousel groupSize={3}>
-            {magList && magList.map(mag => <MagCard key={mag.id} magMetaData={mag} />)}
+            {magList &&
+              magList.slice(1).map((mag, i) => <MagCard key={mag.id} magMetaData={mag} />)}
           </Carousel>
         </Section>
 
         <Section>
-          <a className="section-title">매거진</a>
-          <Carousel groupSize={3}>
-            {magList && magList.map(mag => <MagCard key={mag.id} magMetaData={mag} />)}
-          </Carousel>
-        </Section>
-
-        <Section>
-          <a className="section-title">매거진</a>
-          <Carousel groupSize={3}>
-            {magList && magList.map(mag => <MagCard key={mag.id} magMetaData={mag} />)}
+          <a className="section-title">내 취향 플레이리스트</a>
+          <Carousel groupSize={5}>
+            {playlistList &&
+              playlistList?.map(playlist => (
+                <PlaylistCard key={playlist.id} playlistMetaData={playlist} />
+              ))}
           </Carousel>
         </Section>
       </Content>
@@ -37,10 +39,11 @@ function Today({ magList }) {
   );
 }
 
-const Black = styled.div`
+const MagTopWrapper = styled.div`
   width: 100%;
   padding: 40px 0;
-  background: black;
+  margin-bottom: 16px;
+  background: ${props => props.theme.color.lightgrey};
 `;
 
 const Content = styled.div`

--- a/frontend/src/pages/Today/index.tsx
+++ b/frontend/src/pages/Today/index.tsx
@@ -5,8 +5,7 @@ import Section from '@components/Common/Section';
 import MagCard from '@components/Common/Card/MagCard';
 import MagTopItem from '@components/Common/MagTopItem';
 import PlaylistCard from '@components/Common/Card/PlaylistCard';
-import { GrNext } from 'react-icons/gr';
-import useFetch from '../../hooks/useFetch';
+// import { GrNext } from 'react-icons/gr';
 
 function Today({ magList, playlistList }) {
   console.log('###', playlistList);

--- a/frontend/src/pages/Today/index.tsx
+++ b/frontend/src/pages/Today/index.tsx
@@ -3,36 +3,52 @@ import styled from '@styles/themed-components';
 import Carousel from '@components/Common/Carousel';
 import Section from '@components/Common/Section';
 import MagCard from '@components/Common/Card/MagCard';
+import MagTopItem from '@components/Common/MagTopItem';
 
 function Today({ magList }) {
   return (
     <Wrapper>
-      <Section>
-        <a className="section-title">매거진</a>
-        <Carousel groupSize={3}>
-          {magList && magList.map(mag => <MagCard key={mag.id} magMetaData={mag} />)}
-        </Carousel>
-      </Section>
+      <Black>
+        <MagTopItem />
+      </Black>
+      <Content>
+        <Section>
+          <a className="section-title">매거진</a>
+          <Carousel groupSize={3}>
+            {magList && magList.map(mag => <MagCard key={mag.id} magMetaData={mag} />)}
+          </Carousel>
+        </Section>
 
-      <Section>
-        <a className="section-title">매거진</a>
-        <Carousel groupSize={3}>
-          {magList && magList.map(mag => <MagCard key={mag.id} magMetaData={mag} />)}
-        </Carousel>
-      </Section>
+        <Section>
+          <a className="section-title">매거진</a>
+          <Carousel groupSize={3}>
+            {magList && magList.map(mag => <MagCard key={mag.id} magMetaData={mag} />)}
+          </Carousel>
+        </Section>
 
-      <Section>
-        <a className="section-title">매거진</a>
-        <Carousel groupSize={3}>
-          {magList && magList.map(mag => <MagCard key={mag.id} magMetaData={mag} />)}
-        </Carousel>
-      </Section>
+        <Section>
+          <a className="section-title">매거진</a>
+          <Carousel groupSize={3}>
+            {magList && magList.map(mag => <MagCard key={mag.id} magMetaData={mag} />)}
+          </Carousel>
+        </Section>
+      </Content>
     </Wrapper>
   );
 }
 
-const Wrapper = styled.div`
-  padding-bottom: 200px;
+const Black = styled.div`
+  width: 100%;
+  padding: 40px 0;
+  background: black;
 `;
+
+const Content = styled.div`
+  position: relative;
+  max-width: ${props => props.theme.size.mainContentWidth};
+  margin: auto;
+`;
+
+const Wrapper = styled.div``;
 
 export default Today;

--- a/frontend/src/styles/themes.ts
+++ b/frontend/src/styles/themes.ts
@@ -37,12 +37,14 @@ const color = {
   greyFontColor: '#999',
   drakFontColor: '#232323',
   borderColor: '#e2e2e2',
+  playbarFontColor: '#787878',
 };
 
 const size = {
   sidebarWidth: '225px',
   bigCarouselContentWidth: '310px',
   smallCarouselContentWidth: '180px',
+  playbarheight: '81px',
 };
 
 const font = {

--- a/frontend/src/styles/themes.ts
+++ b/frontend/src/styles/themes.ts
@@ -73,6 +73,11 @@ const font = {
   font-size: 16px;
   color: ${color.drakFontColor};
   `,
+  bigBoldTitle: `
+  font-size: 32px;
+  font-weight : 700;
+  color: ${color.drakFontColor};
+  `,
 };
 
 const theme = {

--- a/frontend/src/styles/themes.ts
+++ b/frontend/src/styles/themes.ts
@@ -45,6 +45,9 @@ const size = {
   bigCarouselContentWidth: '310px',
   smallCarouselContentWidth: '180px',
   playbarheight: '81px',
+  mainContentWidth: '964px',
+  todayContentWidth: '1060px',
+  magTopItemHeight: '320px',
 };
 
 const font = {


### PR DESCRIPTION
## 구현 기능
* FE
  - Common/Card CSS 보완
  - sideBar Router 처리
  - playbar UI 구현
  - today layout css 보완 및 컴포넌트(magTopItem)구현

* BE
  - 부족한 데이터 추가로 삽입 (track, artist 등)
  - get/megazine API 구현


## 스크린 샷
<img width="180" alt="스크린샷 2020-12-09 오전 4 17 31" src="https://user-images.githubusercontent.com/60839959/101530644-86f5b900-39d5-11eb-9466-4a8593f56ea7.png">
<img width="1200" alt="스크린샷 2020-12-09 오전 4 17 18" src="https://user-images.githubusercontent.com/60839959/101530611-80674180-39d5-11eb-920c-ea1ba2c7cbe2.png">
<img width="1200" alt="스크린샷 2020-12-09 오전 4 17 24" src="https://user-images.githubusercontent.com/60839959/101530638-865d2280-39d5-11eb-9ccb-14a0f2548780.png">

