### PR TITLE
[WEB] Auth 웹/모바일 분기처리 & Authorization 오류 수정 & Log schema 속성 추가 

### DIFF
--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -42,9 +42,12 @@ createConnection()
     app.use(bodyParser.urlencoded({ extended: false }));
     app.use(morgan('dev'));
     // TODO: 허용할 주소 정확히 명시하기
+
     app.use(cors());
+
     app.use(passport.initialize());
     passportConfig();
+    app.use(passport.session());
 
     app.use('/api', apiRoute);
 

--- a/backend/src/models/Log.ts
+++ b/backend/src/models/Log.ts
@@ -4,6 +4,7 @@ interface ILog extends Document {
   eventTime?: Date;
   eventName?: string;
   parameters?: any;
+  userInfo?: any;
 }
 
 const MovePageParams = new Schema({
@@ -11,10 +12,17 @@ const MovePageParams = new Schema({
   next: String,
 });
 
+const UserInfoParams = new Schema({
+  isLoggedIn: Boolean,
+  user: Object,
+});
+
 const LogSchema: Schema = new Schema({
   eventTime: Date,
   eventName: String,
   parameters: MovePageParams,
+  userInfo: UserInfoParams,
+  userAgent: String,
 });
 
 const Log: Model<ILog> = model('Log', LogSchema);

--- a/backend/src/passport/jwt.ts
+++ b/backend/src/passport/jwt.ts
@@ -11,15 +11,15 @@ interface JwtPayload {
 
 const passportJwtConfig = (): void => {
   const jwtOptions = {
-    secretOrKey: process.env.JWT_SECRET,
     jwtFromRequest: ExtractJwt.fromHeader('authorization'),
+    secretOrKey: process.env.JWT_SECRET,
   };
 
   const jwtVerify = async (jwtPayload: JwtPayload, done: any): Promise<void> => {
     try {
       const user = await User.findOne({ id: jwtPayload.id });
-      if (user) return done(null, user);
       console.log(user);
+      if (user) return done(null, user);
       return done(null, false);
     } catch (err) {
       console.log(err);

--- a/backend/src/route/auth/controller.ts
+++ b/backend/src/route/auth/controller.ts
@@ -8,8 +8,23 @@ const getToken = (req: Request, res: Response): void => {
     expiresIn: '1h',
     noTimestamp: true,
   });
-  res.cookie('token', token);
-  res.redirect(process.env.SERVICE_URL as string);
+  res.cookie('token', token, { maxAge: 1000 * 60 * 60 * 24 * 1, httpOnly: false });
+  const ua = req.headers['user-agent']?.toLocaleLowerCase();
+  if (
+    (ua && 'lgtelecom'.indexOf(ua) > -1) ||
+    (ua && 'android'.indexOf(ua) > -1) ||
+    (ua && 'blackberry'.indexOf(ua) > -1) ||
+    (ua && 'iphone'.indexOf(ua) > -1) ||
+    (ua && 'ipad'.indexOf(ua) > -1) ||
+    (ua && 'samsung'.indexOf(ua) > -1) ||
+    (ua && 'symbian'.indexOf(ua) > -1) ||
+    (ua && 'sony'.indexOf(ua) > -1) ||
+    (ua && 'SCH-'.indexOf(ua) > -1) ||
+    (ua && 'SPH-'.indexOf(ua) > -1)
+  ) {
+    res.redirect(`minivibe://access?token=${token}`); // 모바일
+  }
+  res.redirect(process.env.SERVICE_URL as string); // 웹
 };
 
 export { getToken };

--- a/backend/src/route/log/controller.ts
+++ b/backend/src/route/log/controller.ts
@@ -5,10 +5,7 @@ const createLog = async (req: Request, res: Response): Promise<void> => {
   const log = new Log(req.body);
   console.log('@@@@ log :', log);
   await log.save((err, logInfo) => {
-    if (err) {
-      console.log(err);
-      return res.json({ success: false, err });
-    }
+    if (err) return res.json({ success: false, err });
     return res.status(200).json({
       success: true,
     });

--- a/backend/src/route/log/controller.ts
+++ b/backend/src/route/log/controller.ts
@@ -2,9 +2,12 @@ import { Request, Response } from 'express';
 import Log from '../../models/Log';
 
 const createLog = async (req: Request, res: Response): Promise<void> => {
-  const log = new Log(req.body);
-  console.log('@@@@ log :', log);
-  await log.save((err, logInfo) => {
+  const logInfo = req.body;
+  logInfo.userInfo = { isLoggedIn: true, user: req.user };
+  logInfo.userAgent = req.headers['user-agent'];
+  const log = new Log(logInfo);
+  console.log('@@@log : ', log);
+  await log.save(err => {
     if (err) return res.json({ success: false, err });
     return res.status(200).json({
       success: true,

--- a/backend/src/route/log/index.ts
+++ b/backend/src/route/log/index.ts
@@ -5,7 +5,7 @@ import createLog from './controller';
 const route = express.Router();
 
 // test API: /POST
-route.post('/', passport.authenticate('naver', { session: false }), createLog);
+route.post('/', passport.authenticate('jwt', { session: false }), createLog);
 // route.post('/', createLog);
 
 export default route;

--- a/frontend/src/api/index.tsx
+++ b/frontend/src/api/index.tsx
@@ -1,28 +1,16 @@
-const token =
-  'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6Mywibmlja25hbWUiOiLslYTroZzrpqwiLCJlbWFpbCI6InNrbmdsZWUyMkBuYXZlci5jb20iLCJwcm9maWxlVVJMIjoiaHR0cHM6Ly9waGluZi5wc3RhdGljLm5ldC9jb250YWN0LzIwMjAwNzA3XzEzNC8xNTk0MDkwNzM4MjIzRFV3d21fSlBFRy8yMDE2MDkxM18xNDMzMTcuanBnIiwiZXhwIjoxNjA3NTEzMjczfQ.b5G4gNeN_qll_dBin0jzQYCD8lOXwf3xbJqHvdVaa88';
-// const API = axios.create({
-//   baseURL: 'localhost:8000/api',
-//   headers: {
-//     'sec-fetch-mode': 'no-cors',
-//     'Content-Type': 'application/json',
-//     'Access-Control-Allow-Origin': '*',
-//     Authorization: token,
-//   },
-// });
+import axios from 'axios';
 
 const fetchData = async data => {
-  console.log('fetchData 시작!');
-  console.log(data);
-  await fetch('http://115.85.181.152:8000/api/log', {
-    method: 'POST',
-    mode: 'no-cors',
+  const token = document.cookie.split('token=')[1];
+  axios.post('http://localhost:8000/api/log', data, {
     headers: {
-      'Content-type': 'application/json',
+      Authorization: token,
       'Access-Control-Allow-Origin': '*',
-      RequestMode: 'no-cors',
-      Authorization: `Bearer ${token}`,
+      'Access-Control-Allow-Credentials': 'true',
+      'Access-Control-Allow-Methods': 'GET, POST, PATCH, DELETE, PUT, OPTIONS',
+      'Access-Control-Allow-Headers':
+        'Content-Type, Access-Control-Allow-Headers, Authorization, X-Requested-With',
     },
-    body: JSON.stringify(data),
   });
 };
 

--- a/frontend/src/components/Common/BoxItem/index.tsx
+++ b/frontend/src/components/Common/BoxItem/index.tsx
@@ -3,14 +3,11 @@ import styled from 'styled-components';
 import { BsThreeDots } from 'react-icons/bs';
 import BoxPlayButton from '@components/Common/Button/BoxPlayButton';
 import { useRouter } from 'next/router';
-import axios from 'axios';
+import fetchData from '../../../api';
 
 interface EventTargetProps {
   onClick?: React.MouseEventHandler<HTMLButtonElement>;
 }
-
-const token =
-  'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6Mywibmlja25hbWUiOiLslYTroZzrpqwiLCJlbWFpbCI6InNrbmdsZWUyMkBuYXZlci5jb20iLCJwcm9maWxlVVJMIjoiaHR0cHM6Ly9waGluZi5wc3RhdGljLm5ldC9jb250YWN0LzIwMjAwNzA3XzEzNC8xNTk0MDkwNzM4MjIzRFV3d21fSlBFRy8yMDE2MDkxM18xNDMzMTcuanBnIiwiZXhwIjoxNjA3NTEzMjczfQ.b5G4gNeN_qll_dBin0jzQYCD8lOXwf3xbJqHvdVaa88';
 
 const eventLogHandler = pathname => {
   const logData = {
@@ -18,17 +15,7 @@ const eventLogHandler = pathname => {
     eventName: 'move_page',
     parameters: { prev: pathname, next: '/magazines/100523' },
   };
-  // fetchData(logData);
-  axios({
-    method: 'post',
-    url: 'http://115.85.181.152:8000/api/log',
-    data: logData,
-    headers: {
-      'Access-Control-Allow-Origin': '*',
-      Authorization: `Bearer ${token}`,
-      withCredentials: true,
-    },
-  });
+  fetchData(logData);
 };
 
 function BoxItem({ imgUrl }) {

--- a/frontend/src/components/Common/Card/MagCard/index.tsx
+++ b/frontend/src/components/Common/Card/MagCard/index.tsx
@@ -34,7 +34,6 @@ const Container = styled.ul`
   width: ${props => props.theme.size.bigCarouselContentWidth};
   display: flex;
   flex-direction: column;
-  border: 10px solid red;
 `;
 
 const MagTitle = styled.a`

--- a/frontend/src/components/Layout/SideBar/NavBar/NavList/index.tsx
+++ b/frontend/src/components/Layout/SideBar/NavBar/NavList/index.tsx
@@ -62,6 +62,7 @@ function NavList() {
         <Link href="/library/playlists">
           <NavItem isSelected={router.pathname === '/library/playlists'}>플레이리스트</NavItem>
         </Link>
+        <a href="minivibe://asdf">미니바이브 테스트</a>
       </NavItemWrapper>
     </Container>
   );

--- a/frontend/src/pages/Today/index.tsx
+++ b/frontend/src/pages/Today/index.tsx
@@ -15,10 +15,8 @@ function Today({ magList, playlistList }) {
         <MagTopItem magData={magList[0]} />
       </MagTopWrapper>
       <Content>
-        <a href="minivibe://asdf">미니바이브</a>
         <Section>
           <a className="section-title">매거진</a>
-
           <Carousel groupSize={3}>
             {magList &&
               magList.slice(1).map((mag, i) => <MagCard key={mag.id} magMetaData={mag} />)}


### PR DESCRIPTION
## 구현 기능
* Auth 웹/ 모바일 분기처리
  - res.headers["userAgent"] 를 사용하여 웹/ 모바일 분기처리
  - 웹 모바일에 따라 redirect 경로 상이하게 지정
* Authorization 오류 수정
  - passport.authenticate('jwt')로 수정
  - fetch -> axios방식으로 변경 및 cors문제 해결을 위한 헤더 옵션 추가
* Log schema 속성 추가 
  - userAgent, userInfo 추가 및 로그 전송 테스트

## Log
<img width="819" alt="스크린샷 2020-12-10 오후 12 36 39" src="https://user-images.githubusercontent.com/60839959/101719089-f5c23780-3ae5-11eb-9f37-796212e8aced.png">
