### PR TITLE
[BE] 토큰 만료 시간 제거, 로그인 여부와 관계 없이 로그 추가하는 기능 구현

### DIFF
--- a/backend/src/passport/jwt.ts
+++ b/backend/src/passport/jwt.ts
@@ -2,7 +2,7 @@ import * as passport from 'passport';
 import { Strategy as JwtStrategy, ExtractJwt } from 'passport-jwt';
 import User from '../entities/User';
 
-interface JwtPayload {
+export interface IJwtPayload {
   id: number;
   nickname: string;
   email: string;
@@ -15,7 +15,7 @@ const passportJwtConfig = (): void => {
     secretOrKey: process.env.JWT_SECRET,
   };
 
-  const jwtVerify = async (jwtPayload: JwtPayload, done: any): Promise<void> => {
+  const jwtVerify = async (jwtPayload: IJwtPayload, done: any): Promise<void> => {
     try {
       const user = await User.findOne({ id: jwtPayload.id });
       console.log(user);

--- a/backend/src/route/auth/controller.ts
+++ b/backend/src/route/auth/controller.ts
@@ -5,7 +5,6 @@ import User from '../../entities/User';
 const getToken = (req: Request, res: Response): void => {
   const { id, nickname, email, profileURL } = req.user as User;
   const token = jwt.sign({ id, nickname, email, profileURL }, process.env.JWT_SECRET as string, {
-    expiresIn: '1h',
     noTimestamp: true,
   });
   if (req.headers['user-agent']?.includes('iPhone')) {

--- a/backend/src/route/log/controller.ts
+++ b/backend/src/route/log/controller.ts
@@ -1,9 +1,17 @@
 import { Request, Response } from 'express';
+import * as jwt from 'jsonwebtoken';
 import Log from '../../models/Log';
+import { IJwtPayload } from '../../passport/jwt';
 
 const createLog = async (req: Request, res: Response): Promise<void> => {
   const logInfo = req.body;
-  logInfo.userInfo = { isLoggedIn: true, user: req.user };
+  try {
+    const token = req.headers.authorization;
+    const user = jwt.verify(token as string, process.env.JWT_SECRET as string) as IJwtPayload;
+    logInfo.userInfo = { isLoggedIn: true, user: user.id };
+  } catch (err) {
+    logInfo.userInfo = { isLoggedIn: false };
+  }
   logInfo.userAgent = req.headers['user-agent'];
   const log = new Log(logInfo);
   console.log('@@@log : ', log);

--- a/backend/src/route/log/controller.ts
+++ b/backend/src/route/log/controller.ts
@@ -13,14 +13,14 @@ const createLog = async (req: Request, res: Response): Promise<void> => {
     logInfo.userInfo = { isLoggedIn: false };
   }
   logInfo.userAgent = req.headers['user-agent'];
-  const log = new Log(logInfo);
-  console.log('@@@log : ', log);
-  await log.save(err => {
-    if (err) return res.json({ success: false, err });
-    return res.status(200).json({
-      success: true,
-    });
-  });
+  try {
+    const log = new Log(logInfo);
+    console.log('@@@log : ', log);
+    await log.save();
+    res.json({ success: true });
+  } catch (err) {
+    res.status(500).json({ success: false });
+  }
 };
 
 export default createLog;


### PR DESCRIPTION
## 구현 기능

- 앱/웹 함께 논의한 내용 대로 토큰 만료 시간을 제거했습니다.
- 로그인 여부와 관계 없이 로그를 추가할 수 있습니다.
  - 로그인이 되어있다면 로그에 로그인 상태임을 표시하고 사용자 고유 ID를 기록합니다.
  - 로그인이 되어있지 않다면 로그에 로그인 상태가 아님을 표시합니다.

## 스크린샷

### 테스트를 위해 하드 코딩 (토큰 만료 시간을 없엔 만큼, 보안을 위해 커밋하지 않았습니다)

![Screen Shot 2020-12-12 at 12 29 14 AM](https://user-images.githubusercontent.com/48378720/101926655-d0811680-3c16-11eb-8d7d-fc7339fa2c61.png)

### 로그 추가 결과

![Screen Shot 2020-12-11 at 11 24 42 PM](https://user-images.githubusercontent.com/48378720/101926679-d971e800-3c16-11eb-8137-78a64ed099b8.png)

(로그인 되어있지 않은 경우 역시 잘 작동합니다.) 

## 고려해보면 좋을 것들

- 프론트 환경 변수 설정
- passport-jwt 사용하지 않고 우리만의 미들웨어 작성하기
  - passport-jwt를 활용해보려고 했지만 생각보다 이 모듈의 자유도가 높지 않은 것 같아요!
  - Authorization 헤더가 없거나, 토큰이 유효하지 않은 경우 401 Status를 반환하는데 이 동작을 입맛대로 수정하는 게 안되는 것 같아요 (passport-jwt GitHub 가서 어떻게 구현되어 있는지 봤는데 그런 것 같음..!!)
- naver OAuth 매번 수정하는게 번거로운데 하나 더 등록할까요? (개발용...) 👀

## 질문

- backend/src/app.ts에 `app.use(passport.session());`는 왜 사용하는 것인지 궁금합니다!
- 프론트에서 useFetch와 api는 분리된 이유가 있을까요?