### PR TITLE
탭 이벤트 구현 및 추가, 버그 수정

### DIFF
--- a/iOS/MiniVIBE/MiniVIBE/UI/Components/AlbumSection/AlbumSectionView.swift
+++ b/iOS/MiniVIBE/MiniVIBE/UI/Components/AlbumSection/AlbumSectionView.swift
@@ -16,7 +16,7 @@ struct AlbumSectionView: View {
     
     var body: some View {
         VStack {
-            MoreHeaderView(title: viewModel.title)
+            MoreHeaderView(title: viewModel.title).emitEventIfTapped(event: TapEvent(view: Self.name, target: Target.more))
             SectionScrollView {
                 ForEach(viewModel.albums.indices) { index in
                     NavigationLink(destination: AlbumDetailView(album: viewModel.albums[index])) {
@@ -32,7 +32,7 @@ struct AlbumSectionView: View {
                                 .lineLimit(1)
                             Text(viewModel.albums[index].artist).vibeMainText()
                         }
-                    }
+                    }.emitEventIfTapped(event: TapEvent(view: Self.name, target: Target.album))
                 }
             }
         }

--- a/iOS/MiniVIBE/MiniVIBE/UI/Components/AlbumSection/AlbumSectionView.swift
+++ b/iOS/MiniVIBE/MiniVIBE/UI/Components/AlbumSection/AlbumSectionView.swift
@@ -16,7 +16,7 @@ struct AlbumSectionView: View {
     
     var body: some View {
         VStack {
-            MoreHeaderView(title: viewModel.title).emitEventIfTapped(event: TapEvent(view: Self.name, target: Target.more))
+            MoreHeaderView(title: viewModel.title).emitEventIfTapped(event: TapEvent(component: Self.name, target: Target.more))
             SectionScrollView {
                 ForEach(viewModel.albums.indices) { index in
                     NavigationLink(destination: AlbumDetailView(album: viewModel.albums[index])) {
@@ -32,7 +32,7 @@ struct AlbumSectionView: View {
                                 .lineLimit(1)
                             Text(viewModel.albums[index].artist).vibeMainText()
                         }
-                    }.emitEventIfTapped(event: TapEvent(view: Self.name, target: Target.album))
+                    }.emitEventIfTapped(event: TapEvent(component: Self.name, target: Target.album))
                 }
             }
         }

--- a/iOS/MiniVIBE/MiniVIBE/UI/Components/FiveRowSongGridSection/FiveRowSongGridView.swift
+++ b/iOS/MiniVIBE/MiniVIBE/UI/Components/FiveRowSongGridSection/FiveRowSongGridView.swift
@@ -20,7 +20,7 @@ struct FiveRowSongGridView: View {
             NavigationLink(destination: FiveRowSongGridMoreView(viewModel: viewModel)
             ) {
             MoreHeaderView(title: viewModel.title, subtitle: viewModel.subtitle)
-            }.emitEventIfTapped(event: TapEvent(view: name, target: Target.more))
+            }.emitEventIfTapped(event: TapEvent(component: name, target: Target.more))
             SectionScrollView {
                 LazyHGrid(rows: rows, spacing: .defaultSpacing) {
                     fiveRowSongGridItemViews
@@ -57,7 +57,7 @@ private extension FiveRowSongGridView {
                 }
                 Spacer()
             }.frame(width: .oneItemImageWidth)
-            .emitEventIfTapped(event: TapEvent(view: name, target: Target.song))
+            .emitEventIfTapped(event: TapEvent(component: name, target: Target.song))
         }
     }
 }

--- a/iOS/MiniVIBE/MiniVIBE/UI/Components/FiveRowSongGridSection/FiveRowSongGridView.swift
+++ b/iOS/MiniVIBE/MiniVIBE/UI/Components/FiveRowSongGridSection/FiveRowSongGridView.swift
@@ -20,7 +20,7 @@ struct FiveRowSongGridView: View {
             NavigationLink(destination: FiveRowSongGridMoreView(viewModel: viewModel)
             ) {
             MoreHeaderView(title: viewModel.title, subtitle: viewModel.subtitle)
-            }
+            }.emitEventIfTapped(event: TapEvent(view: name, target: Target.more))
             SectionScrollView {
                 LazyHGrid(rows: rows, spacing: .defaultSpacing) {
                     fiveRowSongGridItemViews
@@ -57,6 +57,7 @@ private extension FiveRowSongGridView {
                 }
                 Spacer()
             }.frame(width: .oneItemImageWidth)
+            .emitEventIfTapped(event: TapEvent(view: name, target: Target.song))
         }
     }
 }

--- a/iOS/MiniVIBE/MiniVIBE/UI/Components/PlayListSection/PlaylistSectionView.swift
+++ b/iOS/MiniVIBE/MiniVIBE/UI/Components/PlayListSection/PlaylistSectionView.swift
@@ -29,7 +29,7 @@ private extension PlaylistSectionView {
         VStack {
             NavigationLink(destination: PlaylistMoreView(viewModel: viewModel)) {
                 MoreHeaderView(title: viewModel.title)
-            }.emitEventIfTapped(event: TapEvent(view: name, target: Target.more))
+            }.emitEventIfTapped(event: TapEvent(component: name, target: Target.more))
             SectionScrollView {
                 ForEach(viewModel.playlists) { playlist in
                     NavigationLink(destination: PlaylistDetailView(viewModel: PlaylistDetailView.ViewModel(container: viewModel.container, playlist: playlist))) {
@@ -42,7 +42,7 @@ private extension PlaylistSectionView {
                                 .vibeMainText()
                                 .lineLimit(2)
                         }
-                    }.emitEventIfTapped(event: TapEvent(view: name, target: Target.playlist))
+                    }.emitEventIfTapped(event: TapEvent(component: name, target: Target.playlist))
                 }
             }
         }

--- a/iOS/MiniVIBE/MiniVIBE/UI/Components/PlayListSection/PlaylistSectionView.swift
+++ b/iOS/MiniVIBE/MiniVIBE/UI/Components/PlayListSection/PlaylistSectionView.swift
@@ -29,7 +29,7 @@ private extension PlaylistSectionView {
         VStack {
             NavigationLink(destination: PlaylistMoreView(viewModel: viewModel)) {
                 MoreHeaderView(title: viewModel.title)
-            }
+            }.emitEventIfTapped(event: TapEvent(view: name, target: Target.more))
             SectionScrollView {
                 ForEach(viewModel.playlists) { playlist in
                     NavigationLink(destination: PlaylistDetailView(viewModel: PlaylistDetailView.ViewModel(container: viewModel.container, playlist: playlist))) {
@@ -42,9 +42,50 @@ private extension PlaylistSectionView {
                                 .vibeMainText()
                                 .lineLimit(2)
                         }
-                    }
+                    }.emitEventIfTapped(event: TapEvent(view: name, target: Target.playlist))
                 }
             }
+        }
+    }
+}
+
+enum Target: CustomStringConvertible {
+    case login
+    case song
+    case playlist
+    case album
+    case more
+    case like
+    case playPause
+    case next
+    case share
+    case `repeat`
+    case shuffle
+    
+    var description: String {
+        switch self {
+        case .login:
+            return "login"
+        case .song:
+            return "song"
+        case .playlist:
+            return "playlist"
+        case .album:
+            return "album"
+        case .more:
+            return "more"
+        case .like:
+            return "like"
+        case .playPause:
+            return "playpause"
+        case .next:
+            return  "next"
+        case .repeat:
+            return "repeat"
+        case .share:
+            return "share"
+        case .shuffle:
+            return "shuffle"
         }
     }
 }

--- a/iOS/MiniVIBE/MiniVIBE/UI/Extension/String+EventParameters.swift
+++ b/iOS/MiniVIBE/MiniVIBE/UI/Extension/String+EventParameters.swift
@@ -10,5 +10,6 @@ import Foundation
 extension String {
     static let preView: String = "prev"
     static let nextView: String = "next"
+    static let view: String = "view"
     static let target: String = "target"
 }

--- a/iOS/MiniVIBE/MiniVIBE/UI/Extension/String+EventParameters.swift
+++ b/iOS/MiniVIBE/MiniVIBE/UI/Extension/String+EventParameters.swift
@@ -10,6 +10,6 @@ import Foundation
 extension String {
     static let preView: String = "prev"
     static let nextView: String = "next"
-    static let view: String = "view"
+    static let component: String = "view"
     static let target: String = "target"
 }

--- a/iOS/MiniVIBE/MiniVIBE/UI/Extension/View+emitEvent.swift
+++ b/iOS/MiniVIBE/MiniVIBE/UI/Extension/View+emitEvent.swift
@@ -102,8 +102,8 @@ class MoveEvent: Event {
 }
 
 class TapEvent: Event {
-    init(view: String, target: Target) {
-        super.init(name: .tabButton, parameters: [.view: view, .target: target.description])
+    init(component: String, target: Target) {
+        super.init(name: .tabButton, parameters: [.component: component, .target: target.description])
     }
     
     required init(from decoder: Decoder) throws {

--- a/iOS/MiniVIBE/MiniVIBE/UI/Extension/View+emitEvent.swift
+++ b/iOS/MiniVIBE/MiniVIBE/UI/Extension/View+emitEvent.swift
@@ -24,10 +24,13 @@ public func emitEvent(event: Event) {
 
 public enum EventName: CustomStringConvertible {
     case movePage
+    case tabButton
     public var description: String {
         switch self {
         case .movePage:
-        return "move_page"
+            return "move_page"
+        case .tabButton:
+            return "tab_Button"
         }
     }
 }
@@ -91,6 +94,16 @@ class MoveEvent: Event {
         if setPrePath {
             Self.prePath = prev
         }
+    }
+    
+    required init(from decoder: Decoder) throws {
+        fatalError("init(from:) has not been implemented")
+    }
+}
+
+class TapEvent: Event {
+    init(view: String, target: Target) {
+        super.init(name: .tabButton, parameters: [.view: view, .target: target.description])
     }
     
     required init(from decoder: Decoder) throws {

--- a/iOS/MiniVIBE/MiniVIBE/UI/LibraryView/LibraryAlbumView.swift
+++ b/iOS/MiniVIBE/MiniVIBE/UI/LibraryView/LibraryAlbumView.swift
@@ -11,15 +11,17 @@ import Combine
 struct LibraryAlbumView: View {
     @StateObject var viewModel: Self.ViewModel
     var body: some View {
-        LazyVGrid(columns: [.init(.fixed(.twoItemImageWidth)),
-                            .init(.fixed(.twoItemImageWidth))
-        ]) {
-            ForEach(MockItemFactory.albums) { album in
-                NavigationLink(destination: AlbumDetailView(album: album)) {
-                    HStack {
-                        ImageItemView(image: Image(album.imageURLString), type: .two) {
-                            Text(album.title).vibeTitle3()
-                            Text(album.artist).vibeMainText()
+        ScrollView {
+            LazyVGrid(columns: [.init(.fixed(.twoItemImageWidth)),
+                                .init(.fixed(.twoItemImageWidth))
+            ]) {
+                ForEach(MockItemFactory.albums) { album in
+                    NavigationLink(destination: AlbumDetailView(album: album)) {
+                        HStack {
+                            ImageItemView(image: Image(album.imageURLString), type: .two) {
+                                Text(album.title).vibeTitle3()
+                                Text(album.artist).vibeMainText()
+                            }
                         }
                     }
                 }

--- a/iOS/MiniVIBE/MiniVIBE/UI/LibraryView/LibraryAlbumView.swift
+++ b/iOS/MiniVIBE/MiniVIBE/UI/LibraryView/LibraryAlbumView.swift
@@ -25,6 +25,7 @@ struct LibraryAlbumView: View {
                 }
             }
         }
+        
     }
 }
 

--- a/iOS/MiniVIBE/MiniVIBE/UI/LibraryView/LibraryView.swift
+++ b/iOS/MiniVIBE/MiniVIBE/UI/LibraryView/LibraryView.swift
@@ -38,7 +38,6 @@ private extension LibraryView {
             LibraryAlbumView(viewModel: LibraryAlbumView.ViewModel(container: viewModel.container)).tag(2)
             LibraryPlaylistView().tag(3)
         }
-//        .frame(minWidth: 0, maxWidth: .infinity, minHeight: 0, maxHeight: .infinity)
         .animation(.easeInOut)
         .tabViewStyle(PageTabViewStyle(indexDisplayMode: .never))
     }
@@ -175,7 +174,7 @@ struct LibraryPlaylistView: View {
                         }
                     }
 //                }
-            }
+            }.padding(.horizontal, .defaultPadding)
         }
     }
 }

--- a/iOS/MiniVIBE/MiniVIBE/UI/PlayingBar/MusicPlayerView.swift
+++ b/iOS/MiniVIBE/MiniVIBE/UI/PlayingBar/MusicPlayerView.swift
@@ -38,7 +38,7 @@ struct MusicPlayerView: View {
                     Divider().accentColor(.gray)
                     MusicPlayerlistView(isPresented: $isPresented)
                 }
-            }
+            }.frame(idealWidth: .infinity)
         }.onAppear {
             emitEvent(event: MoveEvent(next: Self.name, setPrePath: true))
         }

--- a/iOS/MiniVIBE/MiniVIBE/UI/PlayingBar/MusicPlayerView.swift
+++ b/iOS/MiniVIBE/MiniVIBE/UI/PlayingBar/MusicPlayerView.swift
@@ -90,13 +90,13 @@ private extension MusicPlayerView {
                 Image(systemName: "repeat")
                     .font(.system(size: 20))
                     .foregroundColor(.gray)
-            }).emitEventIfTapped(event: TapEvent(view: Self.name, target: Target.repeat))
+            }).emitEventIfTapped(event: TapEvent(component: Self.name, target: Target.repeat))
             Spacer()
             Button(action: {}, label: {
                 Image(systemName: "paperplane")
                     .font(.system(size: 25))
                     .foregroundColor(.gray)
-            }).emitEventIfTapped(event: TapEvent(view: Self.name, target: Target.share))
+            }).emitEventIfTapped(event: TapEvent(component: Self.name, target: Target.share))
             Spacer()
             Button(action: {
                 musicPlayer.isPlaying.toggle()
@@ -104,20 +104,20 @@ private extension MusicPlayerView {
                 Image(systemName: musicPlayer.isPlaying ? "pause" : "play.fill") .font(.system(size: 40))
                     .foregroundColor(.white)
                     .frame(width: 40, height: 40)
-            }).emitEventIfTapped(event: TapEvent(view: Self.name, target: Target.playPause))
+            }).emitEventIfTapped(event: TapEvent(component: Self.name, target: Target.playPause))
             Spacer()
             Button(action: {}, label: {
                 Image(systemName: "heart.fill")
                     .font(.system(size: 25))
                     .foregroundColor(.gray)
-            }).emitEventIfTapped(event: TapEvent(view: Self.name, target: Target.like))
+            }).emitEventIfTapped(event: TapEvent(component: Self.name, target: Target.like))
             Spacer()
             Button(action: {}, label: {
                 Image(systemName: "shuffle")
                     .font(.system(size: 20))
                     .foregroundColor(.gray)
                     .padding(.vertical)
-            }).emitEventIfTapped(event: TapEvent(view: Self.name, target: Target.shuffle))
+            }).emitEventIfTapped(event: TapEvent(component: Self.name, target: Target.shuffle))
         }
     }
 }

--- a/iOS/MiniVIBE/MiniVIBE/UI/PlayingBar/MusicPlayerView.swift
+++ b/iOS/MiniVIBE/MiniVIBE/UI/PlayingBar/MusicPlayerView.swift
@@ -86,30 +86,39 @@ private extension MusicPlayerView {
 private extension MusicPlayerView {
     var controllerView: some View {
         HStack {
+            Button(action: {}, label: {
                 Image(systemName: "repeat")
                     .font(.system(size: 20))
                     .foregroundColor(.gray)
-                Spacer()
+            }).emitEventIfTapped(event: TapEvent(view: Self.name, target: Target.repeat))
+            Spacer()
+            Button(action: {}, label: {
                 Image(systemName: "paperplane")
                     .font(.system(size: 25))
                     .foregroundColor(.gray)
-                Spacer()
-                Button(action: {
-                    musicPlayer.isPlaying.toggle()
-                }, label: {
-                    Image(systemName: musicPlayer.isPlaying ? "pause" : "play.fill") .font(.system(size: 40))
-                        .foregroundColor(.white)
-                        .frame(width: 40, height: 40)
-                })
-                Spacer()
+            }).emitEventIfTapped(event: TapEvent(view: Self.name, target: Target.share))
+            Spacer()
+            Button(action: {
+                musicPlayer.isPlaying.toggle()
+            }, label: {
+                Image(systemName: musicPlayer.isPlaying ? "pause" : "play.fill") .font(.system(size: 40))
+                    .foregroundColor(.white)
+                    .frame(width: 40, height: 40)
+            }).emitEventIfTapped(event: TapEvent(view: Self.name, target: Target.playPause))
+            Spacer()
+            Button(action: {}, label: {
                 Image(systemName: "heart.fill")
                     .font(.system(size: 25))
                     .foregroundColor(.gray)
-                Spacer()
+            }).emitEventIfTapped(event: TapEvent(view: Self.name, target: Target.like))
+            Spacer()
+            Button(action: {}, label: {
                 Image(systemName: "shuffle")
                     .font(.system(size: 20))
                     .foregroundColor(.gray)
-        }            .padding(.vertical)
+                    .padding(.vertical)
+            }).emitEventIfTapped(event: TapEvent(view: Self.name, target: Target.shuffle))
+        }
     }
 }
 
@@ -144,7 +153,7 @@ private struct MusicPlayerlistView: View {
                         }
                 }.onMove(perform: musicPlayer.move)
             }
-        }
+                  }
     }
 }
 

--- a/iOS/MiniVIBE/MiniVIBE/UI/PlayingBar/NowPlayingBarView.swift
+++ b/iOS/MiniVIBE/MiniVIBE/UI/PlayingBar/NowPlayingBarView.swift
@@ -32,13 +32,13 @@ struct NowPlayingBarView: View {
                     .vibeTitle2()
                     .buttonStyle(PlainButtonStyle())
                     .padding(.horizontal)
-            }).emitEventIfTapped(event: TapEvent(view: Self.name, target: Target.playPause))
+            }).emitEventIfTapped(event: TapEvent(component: Self.name, target: Target.playPause))
             Button(action: {
                 musicPlayer.nextSong()
             }, label: {
                 Image(systemName: "forward.fill").vibeTitle2()
             }).padding(.trailing)
-            .emitEventIfTapped(event: TapEvent(view: Self.name, target: Target.playPause))
+            .emitEventIfTapped(event: TapEvent(component: Self.name, target: Target.playPause))
         }.onTapGesture {
             self.isPresent = true
         }.sheet(isPresented: $isPresent, content: {

--- a/iOS/MiniVIBE/MiniVIBE/UI/PlayingBar/NowPlayingBarView.swift
+++ b/iOS/MiniVIBE/MiniVIBE/UI/PlayingBar/NowPlayingBarView.swift
@@ -32,12 +32,13 @@ struct NowPlayingBarView: View {
                     .vibeTitle2()
                     .buttonStyle(PlainButtonStyle())
                     .padding(.horizontal)
-            })
+            }).emitEventIfTapped(event: TapEvent(view: Self.name, target: Target.playPause))
             Button(action: {
                 musicPlayer.nextSong()
             }, label: {
                 Image(systemName: "forward.fill").vibeTitle2()
             }).padding(.trailing)
+            .emitEventIfTapped(event: TapEvent(view: Self.name, target: Target.playPause))
         }.onTapGesture {
             self.isPresent = true
         }.sheet(isPresented: $isPresent, content: {

--- a/iOS/MiniVIBE/MiniVIBE/UI/TodayView/DJStationSection/DJStationSectionView.swift
+++ b/iOS/MiniVIBE/MiniVIBE/UI/TodayView/DJStationSection/DJStationSectionView.swift
@@ -18,7 +18,7 @@ struct DJStationSectionView: View {
             NavigationLink(destination: DJStationDetailView()
             ) {
                     MoreHeaderView(title: Constant.title)
-            }
+            }.emitEventIfTapped(event: TapEvent(view: Self.name, target: Target.more))
             SectionScrollView {
                 ForEach(items) { item in
                     DJStationItemView(item: item)

--- a/iOS/MiniVIBE/MiniVIBE/UI/TodayView/DJStationSection/DJStationSectionView.swift
+++ b/iOS/MiniVIBE/MiniVIBE/UI/TodayView/DJStationSection/DJStationSectionView.swift
@@ -18,7 +18,7 @@ struct DJStationSectionView: View {
             NavigationLink(destination: DJStationDetailView()
             ) {
                     MoreHeaderView(title: Constant.title)
-            }.emitEventIfTapped(event: TapEvent(view: Self.name, target: Target.more))
+            }.emitEventIfTapped(event: TapEvent(component: Self.name, target: Target.more))
             SectionScrollView {
                 ForEach(items) { item in
                     DJStationItemView(item: item)

--- a/iOS/MiniVIBE/MiniVIBE/UI/TodayView/TodayHeaderView.swift
+++ b/iOS/MiniVIBE/MiniVIBE/UI/TodayView/TodayHeaderView.swift
@@ -28,7 +28,7 @@ struct TodayHeaderView: View {
                 .padding(10)
                 .background(Color(.systemGray4))
                 .clipShape(Circle())
-                .foregroundColor(Color(.systemGray2))})
+                .foregroundColor(Color(.systemGray2))}).emitEventIfTapped(event: TapEvent(view: Self.name, target: Target.login))
         }.padding()
     }
 }

--- a/iOS/MiniVIBE/MiniVIBE/UI/TodayView/TodayHeaderView.swift
+++ b/iOS/MiniVIBE/MiniVIBE/UI/TodayView/TodayHeaderView.swift
@@ -28,7 +28,7 @@ struct TodayHeaderView: View {
                 .padding(10)
                 .background(Color(.systemGray4))
                 .clipShape(Circle())
-                .foregroundColor(Color(.systemGray2))}).emitEventIfTapped(event: TapEvent(view: Self.name, target: Target.login))
+                .foregroundColor(Color(.systemGray2))}).emitEventIfTapped(event: TapEvent(component: Self.name, target: Target.login))
         }.padding()
     }
 }


### PR DESCRIPTION
- 투데이 뷰, 뮤직플레이어 뷰, 하단 재생바 등 눌리는 버튼에 대해 탭 이벤트 방출 동작 구현
- 실기기에서 뮤직플레이어 컨트롤 뷰가 가로로 좁혀지던 문제 수정
- 보관함 탭의 페이지가 올바르게 표시되지 않던 문제 수정

탭 이벤트 방출 동작을 구현했습니다.
이벤트 객체를 상속받고 바로 만들 수 있어서 편했는데, 그동안의 결실이라고 생각되어지네요😀

#149