### PR TITLE
[FE] 에러 로깅 커스텀 훅 추가

### DIFF
--- a/frontend/src/components/Layout/index.tsx
+++ b/frontend/src/components/Layout/index.tsx
@@ -3,8 +3,11 @@ import styled from '@styles/themed-components';
 import SideBar from '@components/Layout/SideBar';
 import PlayBar from '@components/Layout/PlayBar';
 import Footer from '@components/Layout/Footer';
+import useLogError from '@hooks/useLogError';
 
 function Layout({ children }) {
+  useLogError();
+
   return (
     <Wrapper>
       <SideBar />
@@ -34,7 +37,7 @@ const Container = styled.div`
 
 // todaypage 빼고 다 max-width 964임.
 const Content = styled.div`
-  width: auto;;
+  width: auto;
 `;
 
 export default Layout;

--- a/frontend/src/hooks/useLogError.ts
+++ b/frontend/src/hooks/useLogError.ts
@@ -1,0 +1,31 @@
+import { useEffect } from 'react';
+
+// TODO: 어떤 형식으로 서버에 보낼 지 고민해보기
+const errorHandler = ({ error }) => {
+  console.log('************** Error Handler');
+  console.log(error);
+};
+
+const rejectionHandler = ({ reason }) => {
+  console.log('************** Rejection Handler');
+  console.log(reason);
+};
+
+const addErrorLogger = () => {
+  window.addEventListener('error', errorHandler);
+  window.addEventListener('unhandledrejection', rejectionHandler);
+};
+
+const removeErrorLogger = () => {
+  window.removeEventListener('error', errorHandler);
+  window.removeEventListener('unhandledrejection', rejectionHandler);
+};
+
+const useLogError = () => {
+  useEffect(() => {
+    addErrorLogger();
+    return removeErrorLogger;
+  }, []);
+};
+
+export default useLogError;


### PR DESCRIPTION
## 구현 내용

- 클라이언트에서 발생하는 에러 및 처리되지 못한 reject 프라미스를 로깅하는 훅을 구현했습니다.
- 이 훅을 레이아웃 컴포넌트에 추가했습니다.

## 스크린샷

![Screen Shot 2020-12-13 at 7 03 32 PM](https://user-images.githubusercontent.com/48378720/102009072-5cf71a80-3d78-11eb-8d7d-d6d5039e8ab3.png)

테스트를 위해 임의로 에러 및 reject 프라미스를 생성해보았습니다.

### 에러

<img width="1552" alt="Screen Shot 2020-12-13 at 7 05 00 PM" src="https://user-images.githubusercontent.com/48378720/102009074-5ec0de00-3d78-11eb-9513-b4cb27241f88.png">

### 프라미스

<img width="1552" alt="Screen Shot 2020-12-13 at 7 05 20 PM" src="https://user-images.githubusercontent.com/48378720/102009076-5ff20b00-3d78-11eb-86a7-180883ae7f28.png">

콘솔에서 로그를 확인할 수 있습니다. `errorHandler`, `rejectionHandler`에서 서버로 에러 로그를 보내면 될 것 같습니다.

## 논의할 사항

- 어떻게 구현할까 고민하다가 훅으로 만들어보았는데 괜찮을까요?
- 에러 객체를 어떻게 가공하여 서버로 보내면 좋을까요?