### PR TITLE
HTTP리퀘스트에 토큰 포함, Reachability 수정, 코어데이터 객체 레이어 분리

### DIFF
--- a/iOS/MiniVIBE/MiniVIBE/Persistence/Persistence.swift
+++ b/iOS/MiniVIBE/MiniVIBE/Persistence/Persistence.swift
@@ -42,7 +42,7 @@ final class PersistenceController {
         return true
     }
     
-    func saveEvent(event: Event) -> Bool {
+    func saveEvent(event: CoreDataEvent) -> Bool {
         guard let eventEntity = NSEntityDescription.entity(forEntityName: "CDEvent", in: context) else { return false }
         let cdEvent = NSManagedObject(entity: eventEntity, insertInto: context)
         cdEvent.setValue(event.name, forKey: "name")

--- a/iOS/MiniVIBE/MiniVIBE/Repositories/LocalRepository.swift
+++ b/iOS/MiniVIBE/MiniVIBE/Repositories/LocalRepository.swift
@@ -8,8 +8,8 @@
 import SwiftUI
 
 protocol LocalRepository {
-    func fetchEvent() -> [Event]
-    func fetchEvents() -> [Event]
+    func fetchEvent() -> [CoreDataEvent]
+    func fetchEvents() -> [CoreDataEvent]
     func deleteAllEvent()
     func saveEvent(event: Event)
 }
@@ -17,9 +17,9 @@ protocol LocalRepository {
 struct RealLocalRepository: LocalRepository {
     let persistenceStore = PersistenceController()
 
-    func fetchEvent() -> [Event] {
+    func fetchEvent() -> [CoreDataEvent] {
         let cdEvents = persistenceStore.fetch(request: CDEvent.fetchRequest())
-        return cdEvents.map { Event(cdEvent: $0) }
+        return cdEvents.map { CoreDataEvent(cdEvent: $0) }
     }
     
     func deleteAllEvent() {
@@ -27,14 +27,15 @@ struct RealLocalRepository: LocalRepository {
         print(result ? "로컬 데이터 삭제 성공" : "로컬 데이터 삭제 실패")
     }
         
-    func fetchEvents() -> [Event] {
+    func fetchEvents() -> [CoreDataEvent] {
         let events = persistenceStore.fetch(request: CDEvent.fetchRequest())
-        return events.map { event -> Event in
-            Event(cdEvent: event)
+        return events.map { event -> CoreDataEvent in
+            CoreDataEvent(cdEvent: event)
         }
     }
 
     func saveEvent(event: Event) {
-        persistenceStore.saveEvent(event: event)
+        let coreDataEvent = CoreDataEvent(name: event.name, parameter: event.parameters ?? [:])
+        persistenceStore.saveEvent(event: coreDataEvent)
     }
 }

--- a/iOS/MiniVIBE/MiniVIBE/Utilities/Reachability.swift
+++ b/iOS/MiniVIBE/MiniVIBE/Utilities/Reachability.swift
@@ -10,7 +10,7 @@ import Network
 import Combine
 
 class Reachability: ObservableObject {
-    let monitor = NWPathMonitor()
+    let monitor = NWPathMonitor(requiredInterfaceType: .wifi)
     @Published var isConnected: Bool = false
     
     init() {

--- a/iOS/MiniVIBE/MiniVIBE/Utilities/RequestProviding.swift
+++ b/iOS/MiniVIBE/MiniVIBE/Utilities/RequestProviding.swift
@@ -44,6 +44,7 @@ extension RequestProviding {
         request.httpMethod = method.rawValue
         request.allHTTPHeaderFields = headers
         request.httpBody = try body()
+        request.setValue(KeyChain.shared.readTokens(), forHTTPHeaderField: "Authorization")
         return request
     }
 }


### PR DESCRIPTION
- 리퀘스트에 받아온 토큰이 있다면 헤더에 포함되도록 추가
- wifi일때만 쌓은 이벤트를 전송하도록 수정
- 프레임워크 분리를 위한 코어데이터 객체 레이어 분리