### PR TITLE
[BE] 아티스트 상세 API의 트랙 정보에 앨범 정보 추가

### DIFF
--- a/backend/src/services/artist/index.ts
+++ b/backend/src/services/artist/index.ts
@@ -5,7 +5,14 @@ const getArtists = (): Promise<Artist[]> => {
 };
 
 const getArtistByArtistId = (artistId: number): Promise<Artist | undefined> => {
-  return Artist.findOne(artistId, { relations: ['genres', 'tracks', 'albums'] });
+  // return Artist.findOne(artistId, { relations: ['genres', 'tracks', 'albums'] });
+  return Artist.createQueryBuilder('artist')
+    .innerJoinAndSelect('artist.genres', 'genre')
+    .innerJoinAndSelect('artist.tracks', 'track')
+    .innerJoinAndSelect('artist.albums', 'albums')
+    .innerJoinAndSelect('track.album', 'album')
+    .where('artist.id = :artistId', { artistId })
+    .getOne();
 };
 
 export { getArtists, getArtistByArtistId };


### PR DESCRIPTION
## 구현 내용

아티스트 상세 API의 트랙 정보에 앨범 정보를 추가했습니다. 앨범 아트등의 정보에 접근 가능합니다.

## 스크린샷

<img width="1508" alt="Screen Shot 2020-12-15 at 10 54 39 PM" src="https://user-images.githubusercontent.com/48378720/102224173-f5340180-3f28-11eb-9109-4a25025a7f92.png">
