### PR TITLE
[FE] 앨범 디테일 페이지,  말줄임표 css 작업

### DIFF
--- a/frontend/src/components/Common/MagTopItem/index.tsx
+++ b/frontend/src/components/Common/MagTopItem/index.tsx
@@ -19,7 +19,7 @@ function MagTopItem({ magData: mag }) {
             <MagTag type={mag.tag} />
           </TagWrapper>
           <MagTitle>{mag.title}</MagTitle>
-          <MagContent>{trimContentLength(mag.content, 110)}</MagContent>
+          <MagContent>{mag.content}</MagContent>
           <MagContent>{`VIBE MAG · ${mag.date}`}</MagContent>
         </MagContentWrapper>
       </A>
@@ -51,10 +51,20 @@ const MagContentWrapper = styled.div`
 `;
 
 const MagContent = styled.p`
-  ${props => props.theme.font.sub}
-  font-size: 14px;
+  overflow: hidden;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  text-overflow: ellipsis;
+  white-space: normal;
+  word-break: break-all;
+  display: block;
+  display: -webkit-box;
+  height: 40px;
   margin-top: 10px;
-  line-height: 130%;
+  font-size: 14px;
+  line-height: 20px;
+  color: #939393;
+  will-change: transform; 
 `;
 
 const Wrapper = styled.div`

--- a/frontend/src/components/Common/TrackItem/index.tsx
+++ b/frontend/src/components/Common/TrackItem/index.tsx
@@ -5,7 +5,6 @@ import { HiHeart } from 'react-icons/hi';
 import { BsMusicPlayer } from 'react-icons/bs';
 import { RiPlayListLine } from 'react-icons/ri';
 
-import trimContentLength from '@utils/trimContentLength';
 import A from '@components/Common/A';
 
 interface ITrackMetaProps {
@@ -55,7 +54,7 @@ const TrackItem = ({
           </TrackImgWrapper>) :
           (<CountWrapper>{chart}</CountWrapper>)}
         <A next="track" id={track.id} target={target}>
-          <Text>{trimContentLength(track.title, 35)}</Text>
+          <Text>{track.title}</Text>
         </A>
       </TrackWrapper>
       <TrackWrapper>
@@ -104,8 +103,12 @@ const lastWrapperStyle = {
 };
 
 const Text = styled.a`
+  display: inline-block;;
+  width: 280px;
   ${props => props.theme.font.plain}
   white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
 `;
 
 const ArtistName = styled(Text)`


### PR DESCRIPTION
 ## 개발
* 제가 브랜치를 따지 않는 바람에 이전 pr에 작업이 들어갔습니다...  
* 작업 내용 :star: #196 :star: 봐주시면 감사합니다 ㅠㅠ

<img width="1550" alt="스크린샷 2020-12-16 오전 2 24 49" src="https://user-images.githubusercontent.com/41413618/102249716-00e1f100-3f46-11eb-8027-85ed973b2b53.png">
<img width="1550" alt="스크린샷 2020-12-16 오전 2 24 54" src="https://user-images.githubusercontent.com/41413618/102249718-017a8780-3f46-11eb-8e38-46d11b634f88.png">


* 앨범 페이지 헤더를 레이아웃에서 분리 후 재 배치
* 트랙리스트를 앨범 디테일 페이지에 맞게 수정
* 트랙리스트에서도 선택시 헤더 팝업



* 말줄임표 css로 수정
```css
  display: inline-block;;
  width: 280px;
  white-space: nowrap;
  overflow: hidden;
  text-overflow: ellipsis;
```
width정해주고 display속성에 block이 들어가면 됩니다.
나머지는 text-overflow 로 마지막 부분을 ... 으로 표시하는 ellipsis를 사용합니다 !
js로 적용했던 부분을 css로 바꿨습니다. 혹시 몰라서 util 파일은 삭제하지 않았습니다