### PR TITLE
[BE] 로그 Bulk Insert API 추가

### DIFF
--- a/backend/src/route/log/controller.ts
+++ b/backend/src/route/log/controller.ts
@@ -14,8 +14,8 @@ const createLog = async (req: Request, res: Response): Promise<void> => {
     logInfo.userAgent = req.headers['user-agent'];
 
     const log = new Log(logInfo);
-    console.log('-------------------- log : ', log);
-    await log.save();
+    const insertedLog = await log.save();
+    console.log('-------------------- log : ', insertedLog);
     res.json({ success: true });
   } catch (err) {
     res.status(500).json({ success: false });

--- a/backend/src/route/log/controller.ts
+++ b/backend/src/route/log/controller.ts
@@ -22,4 +22,24 @@ const createLog = async (req: Request, res: Response): Promise<void> => {
   }
 };
 
-export default createLog;
+const createBulkLogs = async (req: Request, res: Response): Promise<void> => {
+  try {
+    const logs = req.body as any[];
+    const userAgent = req.headers['user-agent'];
+    let userInfo: any;
+    if (req.user) {
+      const { id: userId } = req.user as IJwtPayload;
+      userInfo = { isLoggedIn: true, user: userId };
+    } else {
+      userInfo = { isLoggedIn: false };
+    }
+
+    const insertedLogs = await Log.insertMany(logs.map(log => ({ ...log, userAgent, userInfo })));
+    console.log('-------------------- bulk logs : ', insertedLogs);
+    res.json({ success: true });
+  } catch (err) {
+    res.status(500).json({ success: false });
+  }
+};
+
+export { createLog, createBulkLogs };

--- a/backend/src/route/log/index.ts
+++ b/backend/src/route/log/index.ts
@@ -3,8 +3,6 @@ import createLog from './controller';
 
 const route = express.Router();
 
-// test API: /POST
 route.post('/', createLog);
-// route.post('/', createLog);
 
 export default route;

--- a/backend/src/route/log/index.ts
+++ b/backend/src/route/log/index.ts
@@ -1,8 +1,9 @@
 import * as express from 'express';
-import createLog from './controller';
+import { createBulkLogs, createLog } from './controller';
 
 const route = express.Router();
 
 route.post('/', createLog);
+route.post('/bulk', createBulkLogs);
 
 export default route;


### PR DESCRIPTION
## 구현 내용

로그의 배열을 한 번에 DB에 삽입하는 API를 구현하였습니다.

### URI

`POST /api/log/bulk`

### Parameters

아래와 같은 형태의 JSON을 HTTP body 담아서 보내면 됩니다.

```
[ { 이벤트를 나타내는 객체/딕셔너리 } ]
```

## 스크린샷

![Screen Shot 2020-12-16 at 10 15 38 PM](https://user-images.githubusercontent.com/48378720/102353357-4527cc80-3fec-11eb-98f0-b9439c286841.png)
