### PR TITLE
[FE] 클라이언트 에러를 서버로 보내는 로직 추가

### DIFF
--- a/frontend/src/hooks/useLogError.ts
+++ b/frontend/src/hooks/useLogError.ts
@@ -1,27 +1,39 @@
 import { useEffect } from 'react';
+import api from '@api/index';
 
-// TODO: 어떤 형식으로 서버에 보낼 지 고민해보기
-const errorHandler = ({ error }) => {
-  console.log('************** Error Handler');
-  console.log(error);
+interface IErrorLog {
+  eventTime: Date;
+  eventName: string;
+  parameters: { log: string };
+}
+
+const createErrorLogObject = (error: Error): IErrorLog => {
+  return {
+    eventTime: new Date(),
+    eventName: 'error_event',
+    parameters: { log: error.message },
+  };
 };
 
-const rejectionHandler = ({ reason }) => {
-  console.log('************** Rejection Handler');
-  console.log(reason);
+const errorHandler = ({ error }: { error: Error }): void => {
+  api.post('/log', createErrorLogObject(error));
 };
 
-const addErrorLogger = () => {
+const rejectionHandler = ({ reason }: { reason: Error }): void => {
+  api.post('/log', createErrorLogObject(reason));
+};
+
+const addErrorLogger = (): void => {
   window.addEventListener('error', errorHandler);
   window.addEventListener('unhandledrejection', rejectionHandler);
 };
 
-const removeErrorLogger = () => {
+const removeErrorLogger = (): void => {
   window.removeEventListener('error', errorHandler);
   window.removeEventListener('unhandledrejection', rejectionHandler);
 };
 
-const useLogError = () => {
+const useLogError = (): void => {
   useEffect(() => {
     addErrorLogger();
     return removeErrorLogger;


### PR DESCRIPTION
## 구현 내용

클라이언트에서 발생한 에러를 서버에 로깅하는 기능을 추가했습니다.

## 스크린샷

일부러 오류를 발생시킨 뒤 테스트 한 결과 서버로 잘 전달됩니다.

![Screen Shot 2020-12-17 at 8 37 39 PM](https://user-images.githubusercontent.com/48378720/102483793-94333780-40a8-11eb-8bdd-b332d78b3da4.png)

