### PR TITLE
[BE]  iPad 분기 로직 수정

### DIFF
--- a/backend/src/route/auth/controller.ts
+++ b/backend/src/route/auth/controller.ts
@@ -5,8 +5,8 @@ import * as authService from '../../services/auth';
 const getToken = (req: Request, res: Response): void => {
   const token = authService.createToken(req.user as IJwtPayload);
   if (
-    req.headers['user-agent']?.includes('iPhone') ||
-    req.headers['user-agent']?.includes('iPad')
+    req.headers['user-agent']?.includes('MiniVIBE') ||
+    req.headers['user-agent']?.includes('MiniVIBE/1')
   ) {
     return res.redirect(`minivibe://token?${token}`); // 모바일
   }


### PR DESCRIPTION
* iPad 분기 로직 수정  
iPad가 버전 업그레이드 되면서
user-agent가 iPad가 아닌 mac... 등 웹과유사하게 들어온다는 사실을 발견.  
리다이렉트 문제 해결을 위해 miniVibe와 miniVibe/1가 user-agent에 포함되어있으면  
모바일/아이패드로 리다이렉트 하는 로직으로 변경함.