### PR TITLE
[FE] Refactor : CDN 이미지 파일 사이즈 지정

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -310,6 +310,11 @@
         }
       }
     },
+    "@babel/helper-plugin-utils": {
+      "version": "7.10.4",
+      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.10.4.tgz",
+      "integrity": "sha512-O4KCvQA6lLiMU9l2eawBPMf1xPP8xPfB3iEQw150hOVTqj/rfXz0ThTb4HEzqQfs2Bmo5Ay8BzxfzVtBrr9dVg=="
+    },
     "@babel/helper-replace-supers": {
       "version": "7.12.11",
       "resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.12.11.tgz",
@@ -421,6 +426,14 @@
       "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.12.11.tgz",
       "integrity": "sha512-N3UxG+uuF4CMYoNj8AhnbAcJF0PiuJ9KHuy1lQmkYsxTer/MAH9UBNHsBoAX/4s6NvlDD047No8mYVGGzLL4hg=="
     },
+    "@babel/plugin-syntax-jsx": {
+      "version": "7.12.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.12.1.tgz",
+      "integrity": "sha512-1yRi7yAtB0ETgxdY9ti/p2TivUxJkTdhu/ZbF9MshVGqOx1TdB3b7xCXs49Fupgg50N45KcAsRP/ZqWjs9SRjg==",
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.10.4"
+      }
+    },
     "@babel/runtime": {
       "version": "7.12.5",
       "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.12.5.tgz",
@@ -489,6 +502,52 @@
         "to-fast-properties": "^2.0.0"
       }
     },
+    "@emotion/babel-plugin": {
+      "version": "11.1.2",
+      "resolved": "https://registry.npmjs.org/@emotion/babel-plugin/-/babel-plugin-11.1.2.tgz",
+      "integrity": "sha512-Nz1k7b11dWw8Nw4Z1R99A9mlB6C6rRsCtZnwNUOj4NsoZdrO2f2A/83ST7htJORD5zpOiLKY59aJN23092949w==",
+      "requires": {
+        "@babel/helper-module-imports": "^7.7.0",
+        "@babel/plugin-syntax-jsx": "^7.12.1",
+        "@babel/runtime": "^7.7.2",
+        "@emotion/hash": "^0.8.0",
+        "@emotion/memoize": "^0.7.5",
+        "@emotion/serialize": "^1.0.0",
+        "babel-plugin-macros": "^2.6.1",
+        "convert-source-map": "^1.5.0",
+        "escape-string-regexp": "^4.0.0",
+        "find-root": "^1.1.0",
+        "source-map": "^0.5.7",
+        "stylis": "^4.0.3"
+      },
+      "dependencies": {
+        "@emotion/memoize": {
+          "version": "0.7.5",
+          "resolved": "https://registry.npmjs.org/@emotion/memoize/-/memoize-0.7.5.tgz",
+          "integrity": "sha512-igX9a37DR2ZPGYtV6suZ6whr8pTFtyHL3K/oLUotxpSVO2ASaprmAe2Dkq7tBo7CRY7MMDrAa9nuQP9/YG8FxQ=="
+        },
+        "escape-string-regexp": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+          "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA=="
+        },
+        "source-map": {
+          "version": "0.5.7",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+          "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
+        },
+        "stylis": {
+          "version": "4.0.6",
+          "resolved": "https://registry.npmjs.org/stylis/-/stylis-4.0.6.tgz",
+          "integrity": "sha512-1igcUEmYFBEO14uQHAJhCUelTR5jPztfdVKrYxRnDa5D5Dn3w0NxXupJNPr/VV/yRfZYEAco8sTIRZzH3sRYKg=="
+        }
+      }
+    },
+    "@emotion/hash": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/@emotion/hash/-/hash-0.8.0.tgz",
+      "integrity": "sha512-kBJtf7PH6aWwZ6fka3zQ0p6SBYzx4fl1LoZXE2RrnYST9Xljm7WfKJrU4g/Xr3Beg72MLrp1AWNUmuYJTL7Cow=="
+    },
     "@emotion/is-prop-valid": {
       "version": "0.8.8",
       "resolved": "https://registry.npmjs.org/@emotion/is-prop-valid/-/is-prop-valid-0.8.8.tgz",
@@ -502,6 +561,40 @@
       "resolved": "https://registry.npmjs.org/@emotion/memoize/-/memoize-0.7.4.tgz",
       "integrity": "sha512-Ja/Vfqe3HpuzRsG1oBtWTHk2PGZ7GR+2Vz5iYGelAw8dx32K0y7PjVuxK6z1nMpZOqAFsRUPCkK1YjJ56qJlgw=="
     },
+    "@emotion/serialize": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@emotion/serialize/-/serialize-1.0.0.tgz",
+      "integrity": "sha512-zt1gm4rhdo5Sry8QpCOpopIUIKU+mUSpV9WNmFILUraatm5dttNEaYzUWWSboSMUE6PtN2j1cAsuvcugfdI3mw==",
+      "requires": {
+        "@emotion/hash": "^0.8.0",
+        "@emotion/memoize": "^0.7.4",
+        "@emotion/unitless": "^0.7.5",
+        "@emotion/utils": "^1.0.0",
+        "csstype": "^3.0.2"
+      }
+    },
+    "@emotion/styled": {
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/@emotion/styled/-/styled-11.0.0.tgz",
+      "integrity": "sha512-498laccxJlBiJqrr2r/fx9q+Pr55D0URP2UyOkoSGLjevb8LLAFWueqthsQ5XijE66iGo7y3rzzEYdA7CHmZEQ==",
+      "requires": {
+        "@babel/runtime": "^7.7.2",
+        "@emotion/babel-plugin": "^11.0.0",
+        "@emotion/is-prop-valid": "^1.0.0",
+        "@emotion/serialize": "^1.0.0",
+        "@emotion/utils": "^1.0.0"
+      },
+      "dependencies": {
+        "@emotion/is-prop-valid": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/@emotion/is-prop-valid/-/is-prop-valid-1.0.0.tgz",
+          "integrity": "sha512-G5X0t7eR9pkhUvAY32QS3lToP9JyNF8It5CcmMvbWjmC9/Yq7IhevaKqxl+me2BKR93iTPiL/h3En1ZX/1G3PQ==",
+          "requires": {
+            "@emotion/memoize": "^0.7.4"
+          }
+        }
+      }
+    },
     "@emotion/stylis": {
       "version": "0.8.5",
       "resolved": "https://registry.npmjs.org/@emotion/stylis/-/stylis-0.8.5.tgz",
@@ -511,6 +604,11 @@
       "version": "0.7.5",
       "resolved": "https://registry.npmjs.org/@emotion/unitless/-/unitless-0.7.5.tgz",
       "integrity": "sha512-OWORNpfjMsSSUBVrRBVGECkhWcULOAJz9ZW8uK9qgxD+87M7jHRcvh/A96XXNhXTLmKcoYSQtBEX7lHMO7YRwg=="
+    },
+    "@emotion/utils": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@emotion/utils/-/utils-1.0.0.tgz",
+      "integrity": "sha512-mQC2b3XLDs6QCW+pDQDiyO/EdGZYOygE8s5N5rrzjSI4M3IejPE/JPndCBwRT9z982aqQNi6beWs1UeayrQxxA=="
     },
     "@fluentui/react-component-event-listener": {
       "version": "0.51.6",
@@ -716,6 +814,11 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-14.14.22.tgz",
       "integrity": "sha512-g+f/qj/cNcqKkc3tFqlXOYjrmZA+jNBiDzbP3kH+B+otKFqAdPgVTGP1IeKRdMml/aE69as5S4FqtxAbl+LaMw==",
       "dev": true
+    },
+    "@types/parse-json": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@types/parse-json/-/parse-json-4.0.0.tgz",
+      "integrity": "sha512-//oorEZjL6sbPcKUaCdIGlIUeH26mgzimjBB77G6XRgnDl/L5wOnpyBGRe/Mmf5CVW3PwEBE1NjiMZ/ssFh4wA=="
     },
     "@types/prop-types": {
       "version": "15.7.3",
@@ -1155,6 +1258,16 @@
         "follow-redirects": "^1.10.0"
       }
     },
+    "babel-plugin-macros": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-macros/-/babel-plugin-macros-2.8.0.tgz",
+      "integrity": "sha512-SEP5kJpfGYqYKpBrj5XU3ahw5p5GOHJ0U5ssOSQ/WBVdwkD2Dzlce95exQTs3jOVWPPKLBN2rlEWkCK7dSmLvg==",
+      "requires": {
+        "@babel/runtime": "^7.7.2",
+        "cosmiconfig": "^6.0.0",
+        "resolve": "^1.12.0"
+      }
+    },
     "babel-plugin-styled-components": {
       "version": "1.12.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-styled-components/-/babel-plugin-styled-components-1.12.0.tgz",
@@ -1484,6 +1597,11 @@
         }
       }
     },
+    "callsites": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
+      "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ=="
+    },
     "camelcase": {
       "version": "6.2.0",
       "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.2.0.tgz",
@@ -1766,6 +1884,18 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
       "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
+    },
+    "cosmiconfig": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-6.0.0.tgz",
+      "integrity": "sha512-xb3ZL6+L8b9JLLCx3ZdoZy4+2ECphCMo2PwqgP1tlfVq6M6YReyzBJtvWWtbDSpNr9hn96pkCiZqUcFEc+54Qg==",
+      "requires": {
+        "@types/parse-json": "^4.0.0",
+        "import-fresh": "^3.1.0",
+        "parse-json": "^5.0.0",
+        "path-type": "^4.0.0",
+        "yaml": "^1.7.2"
+      }
     },
     "create-ecdh": {
       "version": "4.0.4",
@@ -2272,6 +2402,21 @@
         "prr": "~1.0.1"
       }
     },
+    "error-ex": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.2.tgz",
+      "integrity": "sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==",
+      "requires": {
+        "is-arrayish": "^0.2.1"
+      },
+      "dependencies": {
+        "is-arrayish": {
+          "version": "0.2.1",
+          "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
+          "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0="
+        }
+      }
+    },
     "es5-ext": {
       "version": "0.10.53",
       "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.53.tgz",
@@ -2578,6 +2723,11 @@
         "pkg-dir": "^4.1.0"
       }
     },
+    "find-root": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/find-root/-/find-root-1.1.0.tgz",
+      "integrity": "sha512-NKfW6bec6GfKc0SGx1e07QZY9PE99u0Bft/0rzSD5k3sO/vwkVUpDUKVm5Gpp5Ue3YfShPFTX2070tDs5kB9Ng=="
+    },
     "find-up": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
@@ -2738,6 +2888,11 @@
       "integrity": "sha512-Auw9a4AxqWpa9GUfj370BMPzzyncfBABW8Mab7BGWBYDj4Isgq+cDKtx0i6u9jcX9pQDnswsaaOTgTmA5pEjuQ==",
       "optional": true
     },
+    "function-bind": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
+      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
+    },
     "gauge": {
       "version": "2.7.4",
       "resolved": "https://registry.npmjs.org/gauge/-/gauge-2.7.4.tgz",
@@ -2823,6 +2978,14 @@
       "version": "4.2.4",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.4.tgz",
       "integrity": "sha512-WjKPNJF79dtJAVniUlGGWHYGz2jWxT6VhN/4m1NdkbZ2nOsEF+cI1Edgql5zCRhs/VsQYRvrXctxktVXZUkixw=="
+    },
+    "has": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
+      "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
+      "requires": {
+        "function-bind": "^1.1.1"
+      }
     },
     "has-flag": {
       "version": "3.0.0",
@@ -3006,6 +3169,15 @@
       "resolved": "https://registry.npmjs.org/iferr/-/iferr-0.1.5.tgz",
       "integrity": "sha1-xg7taebY/bazEEofy8ocGS3FtQE="
     },
+    "import-fresh": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.0.tgz",
+      "integrity": "sha512-veYYhQa+D1QBKznvhUHxb8faxlrwUnxseDAbAp457E0wLNio2bOSKnjYDhMj+YiAq61xrMGhQk9iXVk5FzgQMw==",
+      "requires": {
+        "parent-module": "^1.0.0",
+        "resolve-from": "^4.0.0"
+      }
+    },
     "imurmurhash": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
@@ -3085,6 +3257,14 @@
       "version": "1.1.6",
       "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
       "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w=="
+    },
+    "is-core-module": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.2.0.tgz",
+      "integrity": "sha512-XRAfAdyyY5F5cOXn7hYQDqh2Xmii+DEfIcQGxK/uNwMHhIkPWO0g8msXcbzLe+MpGoR951MlqM/2iIlU4vKDdQ==",
+      "requires": {
+        "has": "^1.0.3"
+      }
     },
     "is-data-descriptor": {
       "version": "0.1.4",
@@ -3220,6 +3400,11 @@
       "resolved": "https://registry.npmjs.org/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz",
       "integrity": "sha512-mrqyZKfX5EhL7hvqcV6WG1yYjnjeuYDzDhhcAAUrq8Po85NBQBJP+ZDUT75qZQ98IkUoBqdkExkukOU7Ts2wrw=="
     },
+    "json-parse-even-better-errors": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
+      "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w=="
+    },
     "json-schema-traverse": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
@@ -3256,6 +3441,11 @@
         "isarray": "^1.0.0",
         "isobject": "^2.0.0"
       }
+    },
+    "lines-and-columns": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.1.6.tgz",
+      "integrity": "sha1-HADHQ7QzzQpOgHWPe2SldEDZ/wA="
     },
     "loader-runner": {
       "version": "2.4.0",
@@ -4057,6 +4247,14 @@
         }
       }
     },
+    "parent-module": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
+      "integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
+      "requires": {
+        "callsites": "^3.0.0"
+      }
+    },
     "parse-asn1": {
       "version": "5.1.6",
       "resolved": "https://registry.npmjs.org/parse-asn1/-/parse-asn1-5.1.6.tgz",
@@ -4067,6 +4265,17 @@
         "evp_bytestokey": "^1.0.0",
         "pbkdf2": "^3.0.3",
         "safe-buffer": "^5.1.1"
+      }
+    },
+    "parse-json": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.2.0.tgz",
+      "integrity": "sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==",
+      "requires": {
+        "@babel/code-frame": "^7.0.0",
+        "error-ex": "^1.3.1",
+        "json-parse-even-better-errors": "^2.3.0",
+        "lines-and-columns": "^1.1.6"
       }
     },
     "pascalcase": {
@@ -4094,6 +4303,16 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
       "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
+    },
+    "path-parse": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
+      "integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw=="
+    },
+    "path-type": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
+      "integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw=="
     },
     "pbkdf2": {
       "version": "3.1.1",
@@ -4620,6 +4839,20 @@
       "version": "1.6.1",
       "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
       "integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc="
+    },
+    "resolve": {
+      "version": "1.19.0",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.19.0.tgz",
+      "integrity": "sha512-rArEXAgsBG4UgRGcynxWIWKFvh/XZCcS8UJdHhwy91zwAvCZIbcs+vAbflgBnNjYMs/i/i+/Ux6IZhML1yPvxg==",
+      "requires": {
+        "is-core-module": "^2.1.0",
+        "path-parse": "^1.0.6"
+      }
+    },
+    "resolve-from": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
+      "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g=="
     },
     "resolve-url": {
       "version": "0.2.1",
@@ -6269,6 +6502,11 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
       "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
+    },
+    "yaml": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.0.tgz",
+      "integrity": "sha512-yr2icI4glYaNG+KWONODapy2/jDdMSDnrONSjblABjD9B4Z5LgiircSt8m8sRZFNi08kG9Sm0uSHtEmP3zaEGg=="
     },
     "yocto-queue": {
       "version": "0.1.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -27,6 +27,7 @@
   },
   "homepage": "https://github.com/boostcamp-2020/Project01-C-User-Event-Collector#readme",
   "dependencies": {
+    "@emotion/styled": "^11.0.0",
     "@types/next": "^9.0.0",
     "@types/react": "^17.0.0",
     "axios": "^0.21.0",

--- a/frontend/src/components/Common/Card/MagCard/index.tsx
+++ b/frontend/src/components/Common/Card/MagCard/index.tsx
@@ -24,11 +24,18 @@ const enterTitle = title => {
 
 const MagCard = ({ magMetaData: mag }: IMagMetaProps) => {
   const target = 'MagCard';
+  const resetImgSize = url => {
+    if (url) {
+      const _url = url.replace(/type=r([0-9])+Fll/gi, 'type=r360Fll');
+      return _url;
+    }
+  };
+
   return (
     <Container>
       <BoxItem
         trackData={mag.tracks}
-        imgUrl={mag.imgUrl}
+        imgUrl={resetImgSize(mag.imgUrl)}
         next="magazines"
         id={mag.id}
         target={target}

--- a/frontend/src/components/Common/MagTag/index.tsx
+++ b/frontend/src/components/Common/MagTag/index.tsx
@@ -45,13 +45,21 @@ const All = styled.a`
   background: ${props => props.theme.color.highlight};
 `;
 
-const SpecialTag = styled(All)`
+const SpecialTag = styled.a`
+  padding: 5px 16px;
+  border-radius: 30px;
   background: linear-gradient(to right, red, #ff00a0, #7e00e4);
 `;
 
-const PickTag = styled(All)``;
+const PickTag = styled.a`
+  padding: 5px 16px;
+  border-radius: 30px;
+  background: ${props => props.theme.color.highlight};
+`;
 
-const GenreTag = styled(All)`
+const GenreTag = styled.a`
+  padding: 5px 16px;
+  border-radius: 30px;
   background: #7e00e4;
 `;
 

--- a/frontend/src/components/Common/MagTopItem/index.tsx
+++ b/frontend/src/components/Common/MagTopItem/index.tsx
@@ -7,13 +7,21 @@ import BoxItem from '@components/Common/BoxItem';
 
 function MagTopItem({ magData: mag }) {
   const target = 'MagTopItem';
+
+  const resetImgSize = url => {
+    if (url) {
+      const _url = url.replace(/type=r([0-9])+Fll/gi, 'type=r360Fll');
+      return _url;
+    }
+  };
+
   return (
     <Wrapper>
       <ImgWrapper>
         <BoxItem
           trackData={mag.tracks}
           target={target}
-          imgUrl={mag.imgUrl}
+          imgUrl={resetImgSize(mag.imgUrl)}
           next="magazines"
           id={mag.id}
         />

--- a/frontend/src/components/Common/PlayTrackItem/index.tsx
+++ b/frontend/src/components/Common/PlayTrackItem/index.tsx
@@ -31,11 +31,18 @@ function PlayTrackItem({ type, trackData: track }) {
     };
   };
 
+  const resetImgSize = url => {
+    if (url) {
+      const _url = url.replace(/type=r([0-9])+Fll/gi, 'type=r120Fll');
+      return _url;
+    }
+  };
+
   return (
     <TrackWrapper>
       <TrackImgWrapper>
         <A next="album" id={track?.album?.id} target={target}>
-          <TrackImg src={track?.album?.imgUrl} alt="playbar-track-img" />
+          <TrackImg src={resetImgSize(track?.album?.imgUrl)} alt="playbar-track-img" />
         </A>
       </TrackImgWrapper>
       <TrackContentWrapper>

--- a/frontend/src/components/Common/TrackItem/index.tsx
+++ b/frontend/src/components/Common/TrackItem/index.tsx
@@ -25,6 +25,11 @@ type TrackMeta = {
   imgUrl: string;
 };
 
+const resetImgSize = url => {
+  const _url = url.replace(/type=r([0-9])+Fll/gi, 'type=r120Fll');
+  return _url;
+};
+
 const TrackItem = ({
   chart,
   type,
@@ -49,7 +54,11 @@ const TrackItem = ({
           <TrackImgWrapper>
             <TrackHoverImg src="/images/track-hover-img.png" className="track-hover-img" />
             <TrackImg
-              src={track.album?.imgUrl ? track.album.imgUrl : albumData.imgUrl}
+              src={
+                track.album?.imgUrl
+                  ? resetImgSize(track.album.imgUrl)
+                  : resetImgSize(albumData.imgUrl)
+              }
               alt="track-image"
             />
           </TrackImgWrapper>

--- a/frontend/src/components/Layout/SideBar/NavBar/index.tsx
+++ b/frontend/src/components/Layout/SideBar/NavBar/index.tsx
@@ -30,13 +30,13 @@ function NavBar() {
     <Container>
       {userState.isLoggedIn ? (
         <AuthWrapper>
-          <ProfileImg src={userState?.profileURL} alt="profile-img" />
+          <ProfileImg src={`${userState?.profileURL}?type=s33`} alt="profile-img" />
           {userState?.nickname}
           <AuthDropdown />
         </AuthWrapper>
       ) : (
         <AuthWrapper style={{ cursor: 'pointer' }} onClick={loginEvent}>
-          <ProfileImg src={userState?.profileURL} alt="profile-img" />
+          <ProfileImg src={`${userState?.profileURL}?type=s33`} alt="profile-img" />
           로그인
         </AuthWrapper>
       )}

--- a/frontend/src/components/Template/Library/index.tsx
+++ b/frontend/src/components/Template/Library/index.tsx
@@ -18,16 +18,18 @@ function Layout({ mainTitle, type, children }: ILayout): ReactElement {
           <SubTitle>보관함</SubTitle>
           <MainTitle>{mainTitle}</MainTitle>
         </Title>
-        {type && (
-          <PlayButtonWrapper>
-            <ClickEventWrapper target="PlayAllBtn">
-              <LargeButton customType="play" />
-            </ClickEventWrapper>
-            <ClickEventWrapper target="shuffle">
-              <LargeButton customType="shuffle" />
-            </ClickEventWrapper>
-          </PlayButtonWrapper>
-        )}
+        <PlayButtonWrapper>
+          {type && (
+            <>
+              <ClickEventWrapper target="PlayAllBtn">
+                <LargeButton customType="play" />
+              </ClickEventWrapper>
+              <ClickEventWrapper target="shuffleBtn">
+                <LargeButton customType="shuffle" />
+              </ClickEventWrapper>
+            </>
+          )}
+        </PlayButtonWrapper>
       </Header>
       <LibraryContent>{children}</LibraryContent>
     </Wrapper>
@@ -45,9 +47,11 @@ const Wrapper = styled.div`
 `;
 
 const Header = styled.header`
-  position: relative;
   height: 80px;
   border-bottom: 1px solid #e4e4e4;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
 `;
 
 const Title = styled.div`
@@ -67,9 +71,10 @@ const MainTitle = styled.span`
 
 const PlayButtonWrapper = styled.div`
   width: 296px;
-  position: absolute;
+  height: 60px;
   display: flex;
   justify-content: space-between;
+  align-items: flex-end;
   bottom: 18px;
   right: 0px;
 `;


### PR DESCRIPTION
## 구현 기능

네이버 VIBE 서비스에서 제공하는 정적 파일들(이미지)은 pstatic.net이라는 별도의 서버를 거쳐 제공됩니다.
이는 CDN을 위한 것으로 추측됩니다.

lighthouse를 통해 웹 성능을 확인하니 적절하지 않은 이미지 사이즈를 가진 이미지 파일들로 인해
성능이 저하됨을 확인하였습니다. 이를 해결하기 위해 resetImgSize라는 함수를 만들어
DB에서 가져온, pstatic.net을 거치는 이미지 url에서 'type=사이즈' 형태로 추가 or 수정함으로써
컴포넌트별 화면에서 보여지는 사이즈만큼 이미지사이즈를 조정하여 성능을 개선할 수 있었습니다.

<img width="611" alt="스크린샷 2021-02-14 오후 4 56 29" src="https://user-images.githubusercontent.com/60839959/107871510-9ddcee00-6ee5-11eb-86ec-0589ffd45fc9.png">
