### PR TITLE
[FE] Refactor : 리플로우 최적화

### DIFF
--- a/frontend/src/components/Common/BoxItem/index.tsx
+++ b/frontend/src/components/Common/BoxItem/index.tsx
@@ -23,7 +23,9 @@ function BoxItem({ trackData, imgUrl, target, next, id }: IBoxItemProps) {
 
         <ButtonsWrapper className="buttons-wrapper">
           <BoxPlayButton />
-          <BsThreeDots size={24} />
+          <DotsButtonWrapper>
+            <BsThreeDots size={24} />
+          </DotsButtonWrapper>
         </ButtonsWrapper>
         <BoxDropdown trackData={trackData} type={next} id={id} />
       </Wrapper>
@@ -44,10 +46,13 @@ const ButtonsWrapper = styled.div`
   height: 18%;
   display: flex;
   align-items: flex-end;
-  justify-content: space-between;
-  transition: 0.5s all;
   opacity: 0;
   background: linear-gradient(to bottom, transparent, rgba(0, 0, 0, 0.15));
+`;
+
+const DotsButtonWrapper = styled.div`
+  position: absolute;
+  right: 12px;
 `;
 
 const Wrapper = styled.div`

--- a/frontend/src/components/Common/Button/BoxPlayButton.tsx
+++ b/frontend/src/components/Common/Button/BoxPlayButton.tsx
@@ -29,6 +29,8 @@ const ButtonWrapper = styled.button`
   align-items: center;
   box-sizing: border-box;
   border: none;
+  position: absolute;
+  will-change: transform;
   &:hover {
     opacity: 100%;
     transform: scale(1.1);

--- a/frontend/src/components/Common/MagTopItem/index.tsx
+++ b/frontend/src/components/Common/MagTopItem/index.tsx
@@ -77,7 +77,6 @@ const MagContent = styled.p`
   font-size: 14px;
   line-height: 20px;
   color: #939393;
-  will-change: transform;
 `;
 
 const Wrapper = styled.div`

--- a/frontend/src/components/MagList/index.tsx
+++ b/frontend/src/components/MagList/index.tsx
@@ -6,12 +6,13 @@ import MagLargeCard from '@components/Common/Card/MagLargeCard';
 const MagList = ({ magList }) => {
   return (
     <ListContainer>
-      {magList && magList?.map((track, index) => (
-        <>
-          {index > 0 && (<DivdieContainer />)}
-          <MagLargeCard key={track.id} data={track}/>
-        </>
-      ))}
+      {magList &&
+        magList?.map((track, index) => (
+          <>
+            {index > 0 && <DivdieContainer />}
+            <MagLargeCard key={track.id} data={track} />
+          </>
+        ))}
     </ListContainer>
   );
 };

--- a/frontend/src/pages/Detail/Magazine/index.tsx
+++ b/frontend/src/pages/Detail/Magazine/index.tsx
@@ -32,11 +32,7 @@ function MagazineDetail({ magazineInfo: magazine }: IMagazineInfoProps) {
             <MagTitle>{magazine?.title}</MagTitle>
             <MagContent>{magazine?.content}</MagContent>
             <MagPlayList>
-              <MagPlayListInfo>
-                총{magazine?.tracks?.length}
-                곡
-{' '}
-              </MagPlayListInfo>
+              <MagPlayListInfo>총{magazine?.tracks?.length}곡 </MagPlayListInfo>
               <MagPlayListLink>플레이리스트 보기</MagPlayListLink>
             </MagPlayList>
             <MagPlayButtonList>
@@ -157,7 +153,6 @@ const MagContent = styled.h5`
   line-height: 26px;
   color: hsla(0, 0%, 100%, 0.5);
   white-space: pre-line;
-
   ::after {
     content: '';
     display: block;


### PR DESCRIPTION
## 구현 기능

Reflow 최적화 방법에 대해 학습하고 본 프로젝트에 일부를 적용해 보았습니다.
1) 사용되지 않는 CSS will-change 속성 제거
브라우저는 모든 요소에 대해 이미 최적화를 시키려고 시도하고 있습니다.
will-change 속성이 사용된 요소는 최적화를 하기 위해 많은 자원을 소모하므로 사용에 신중해야합니다.
본 프로젝트에서 사용한 will-change 속성의 경우, transform이 발생하지 않는 요소에 대해 will-change 속성이 적용되어 있었으며,
효과 발생 이후 will-change로 지정한 속성을 삭제하는 코드가 존재하지 않았기 때문에 사용되지 않는 코드라 판단하여 제거하였습니다.

2) 애니메이션이 들어간 엘리먼트(PlayButton)의 position을 absolute로 지정
why?
-> 일반적으로 JS나 CSS로 width/height 또는 위치이동을 구현한 애니메이션은 초 단위로 상당한 Reflow를 불러일으킵니다.  
이러한 경우에 해당 개체의 position 속성을 fixed 또는 absoute로 주게 되면 다른 요소들의 레이아웃에 영향을 끼치지 않으므로 페이지 전체의 Reflow 대신 해당 애니메이션요소의 Repaint만을 유발합니다.
