### PR TITLE
[FE] Feat : useSWR mutate 메서드를 사용하여 데이터 변경사항 즉시 반영하기

### DIFF
--- a/frontend/src/components/ArtistList/index.tsx
+++ b/frontend/src/components/ArtistList/index.tsx
@@ -1,13 +1,40 @@
 import React from 'react';
 import styled from '@styles/themed-components';
 import ArtistCard from '@components/Common/Card/ArtistCard';
+import { mutate } from 'swr';
+import api from '@api/index';
+import { useAuthDispatch } from '@context/AuthContext';
 
 const ArtistList = ({ artistList }) => {
+  const dispatch = useAuthDispatch();
+
+  const fetchData = async id => {
+    await api.delete(`library/artists/${id}`);
+    dispatch({ type: 'DELETE_ARTIST', artistId: id });
+    const updatedArtists = await artistList.filter(artist => artist.id !== id);
+    mutate(
+      '/library/artists',
+      data => {
+        return { ...data, data: updatedArtists };
+      },
+      false,
+    );
+  };
+
+  const deleteArtist = (e, id) => {
+    fetchData(id);
+  };
+
   return (
     <ListContainer>
       {artistList
         ? artistList?.map(artist => (
-          <ArtistCard key={artist.id} artistMetaData={artist} type="myArtist" />
+            <ArtistCard
+            key={artist.id}
+            artistMetaData={artist}
+            deleteArtist={deleteArtist}
+            type="myArtist"
+          />
           ))
         : null}
     </ListContainer>

--- a/frontend/src/components/Common/Card/ArtistCard/index.tsx
+++ b/frontend/src/components/Common/Card/ArtistCard/index.tsx
@@ -4,7 +4,6 @@ import CircleImage from '@components/Common/CircleImage';
 import CircleHeartButton from '@components/Common/Button/CircleHeartButton';
 import A from '@components/Common/A';
 import api from '@api/index';
-import { mutate } from 'swr';
 import logEventHandler from '@utils/logEventHandler';
 import ClickEventWrapper from '@components/EventWrapper/ClickEventWrapper';
 import { useAuthDispatch } from '@context/AuthContext';
@@ -12,6 +11,7 @@ import { useAuthDispatch } from '@context/AuthContext';
 interface IArtistMetaProps {
   artistMetaData: ArtistMeta;
   type?: string | null;
+  deleteArtist?: any;
 }
 
 interface ArtistMeta {
@@ -21,18 +21,8 @@ interface ArtistMeta {
   imgUrl: string;
 }
 
-const ArtistCard = ({ artistMetaData: artist, type }: IArtistMetaProps) => {
+const ArtistCard = ({ artistMetaData: artist, type, deleteArtist }: IArtistMetaProps) => {
   const target = 'ArtistCard';
-  const dispatch = useAuthDispatch();
-
-  const deleteArtist = async (e, id) => {
-    await api.delete(`library/artists/${id}`);
-    e.target.closest('.artist-card').style.opacity = '0';
-    e.target.closest('.artist-card').style.transform = 'translate(0px, -35px)';
-    dispatch({ type: 'DELETE_ARTIST', artistId: id });
-    mutate(`${process.env.NEXT_PUBLIC_API_BASE_URL}/library/artists`);
-  };
-
   return (
     <Container className="artist-card">
       <ImageContainer>

--- a/frontend/src/components/Common/Dropdown/ArtistDropdown.tsx
+++ b/frontend/src/components/Common/Dropdown/ArtistDropdown.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import styled from '@styles/themed-components';
 import { Dropdown } from 'semantic-ui-react';
-import api from '@api/index';
 import logEventHandler from '@utils/logEventHandler';
 import ClickEventWrapper from '@components/EventWrapper/ClickEventWrapper';
 import * as T from '../../../constants/dropdownText';
@@ -12,19 +11,11 @@ interface ILogData {
   parameters: any;
 }
 
-const ArtistDropdown = id => {
-  const postLog = logData => {
-    api.post('/log', logData);
-  };
-
+function ArtistDropdown({ id, addArtistEvent }) {
   const libraryLogData: ILogData = {
     eventTime: new Date(),
     eventName: 'library_event',
     parameters: { action: 'add', type: 'artist', id },
-  };
-
-  const addLibraryEvent = () => {
-    api.post('/library/artists', { artistId: id }).then(() => postLog(libraryLogData));
   };
 
   return (
@@ -39,7 +30,7 @@ const ArtistDropdown = id => {
             <Dropdown.Item
               style={dropdownItemStyle}
               text={T.LIKE}
-              onClick={logEventHandler(addLibraryEvent, libraryLogData)}
+              onClick={logEventHandler(addArtistEvent, libraryLogData)}
             />
           </ClickEventWrapper>
           <ClickEventWrapper target="ShareBtn/artist" id={id}>
@@ -49,7 +40,7 @@ const ArtistDropdown = id => {
       </Dropdown>
     </Wrapper>
   );
-};
+}
 
 const authDropdownStyle = {
   width: '100%',

--- a/frontend/src/utils/logEventHandler.tsx
+++ b/frontend/src/utils/logEventHandler.tsx
@@ -1,8 +1,16 @@
+import { mutate } from 'swr';
 import api from '../api';
 
-const postLog = logData => {
+const postLog = async logData => {
   const timeStampedLog = { ...logData, eventTime: new Date() };
-  api.post('/log', timeStampedLog);
+  await api.post('/log', timeStampedLog);
+  mutate(
+    '/log',
+    data => {
+      return { ...data, data: [...data.data, logData] };
+    },
+    true,
+  );
 };
 
 const logEventHandler = (handler, logData) => {


### PR DESCRIPTION
## 구현기능
- useSWR의 mutate를 사용한 캐시 업데이트
    - useFetch(swr 커스텀 훅)을 사용하여 데이터를 받아온 경우, swr은 내부적으로 url을 키로서 캐시로 데이터를 관리합니다.
    - 이때 데이터를 추가, 삭제하는 이벤트가 발생할 경우, 데이터의 변경사항을 화면에 바로 반영하고 싶었습니다.
    이를 위해 useSWR의 mutate 메서드를 사용했습니다.
    - mutate를 사용하여 데이터를 가져온 url key값을 첫번째 인자로 전달한 뒤, 업데이트 된 데이터를 두번째 인자로 넣어 캐시를 업데이트 하여 화면에는 업데이트 된 캐시로 구성하도록 하였습니다.
    - 이때 세번째 인자로 true값을 넣음으로써 데이터를 refetch하여 대체하였습니다.
    - 데이터가 변경되는 동안에는 변경된 캐시 데이터로 화면을 구성하고 이후 실제 refetch된 데이터로 대체함으로써 지연없이 데이터의 변경사항을 화면에 반영할 수 있었습니다.

```tsx
  const addTrackEvent = async () => {
    await api.post(`library/tracks`, { trackId: track.id });
    mutate(
      '/library/tracks',
      data => {
        return { ...data, data: [...data.data, track].sort((a, b) => a.id - b.id) };
      },
      true,
    );
    dispatch({ type: 'ADD_TRACK', trackId: track.id });
  };
```